### PR TITLE
fix(deploy): replace node_compat with nodejs_compat for Wrangler v4

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -2,5 +2,5 @@
   "name": "ninjaone-mcp",
   "main": "dist/worker.js",
   "compatibility_date": "2026-02-01",
-  "node_compat": true
+  "compatibility_flags": ["nodejs_compat"]
 }


### PR DESCRIPTION
## Summary

Wrangler v4 removed support for the `node_compat` field in `wrangler.json` and requires the `nodejs_compat` compatibility flag instead. This causes Cloudflare Worker deployments (including the Deploy to Cloudflare button) to fail with:

```
Processing wrangler.json configuration: Removed: "node_compat"
```

## Changes

- Removed `"node_compat": true` from `wrangler.json`
- Added `"compatibility_flags": ["nodejs_compat"]`

Per [Cloudflare's docs](https://developers.cloudflare.com/workers/runtime-apis/nodejs), `nodejs_compat` is a superset of the legacy polyfills plus natively implemented Node.js APIs.

Related: wyre-technology/autotask-mcp#50