### PR TITLE
feat: add Canada, US2, and Federal region support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "user_config": {
     "ninjaone_client_id": { "type": "string", "title": "NinjaOne Client ID", "description": "Your NinjaOne OAuth client ID", "sensitive": true, "required": true },
     "ninjaone_client_secret": { "type": "string", "title": "NinjaOne Client Secret", "description": "Your NinjaOne OAuth client secret", "sensitive": true, "required": true },
-    "ninjaone_region": { "type": "string", "title": "NinjaOne Region", "description": "Region: us, eu, or oc (default: us)", "sensitive": false, "required": false }
+    "ninjaone_region": { "type": "string", "title": "NinjaOne Region", "description": "Region: us, eu, oc, ca, us2, or fed (default: us)", "sensitive": false, "required": false }
   },
   "compatibility": { "platforms": ["darwin", "win32", "linux"], "runtimes": { "node": ">=18.0.0" }, "claude_desktop": ">=0.10.0" }
 }

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -32,6 +32,9 @@ describe("Type Utilities", () => {
       expect(isValidRegion("us")).toBe(true);
       expect(isValidRegion("eu")).toBe(true);
       expect(isValidRegion("oc")).toBe(true);
+      expect(isValidRegion("ca")).toBe(true);
+      expect(isValidRegion("us2")).toBe(true);
+      expect(isValidRegion("fed")).toBe(true);
     });
 
     it("should return false for invalid regions", () => {
@@ -53,6 +56,18 @@ describe("Type Utilities", () => {
 
     it("should return correct URL for OC region", () => {
       expect(getBaseUrlForRegion("oc")).toBe("https://oc.ninjarmm.com");
+    });
+
+    it("should return correct URL for CA region", () => {
+      expect(getBaseUrlForRegion("ca")).toBe("https://ca.ninjarmm.com");
+    });
+
+    it("should return correct URL for US2 region", () => {
+      expect(getBaseUrlForRegion("us2")).toBe("https://us2.ninjarmm.com");
+    });
+
+    it("should return correct URL for FED region", () => {
+      expect(getBaseUrlForRegion("fed")).toBe("https://fed.ninjarmm.com");
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * Credentials are provided via environment variables:
  * - NINJAONE_CLIENT_ID
  * - NINJAONE_CLIENT_SECRET
- * - NINJAONE_REGION (us, eu, oc)
+ * - NINJAONE_REGION (us, eu, oc, ca, us2, fed)
  *
  * Or via gateway headers (when AUTH_MODE=gateway):
  * - X-Ninja-Client-ID

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -36,7 +36,7 @@ export function getCredentials(): NinjaOneCredentials | null {
   }
 
   if (!isValidRegion(regionEnv)) {
-    logger.warn("Invalid region configured", { region: regionEnv, valid: ["us", "eu", "oc"] });
+    logger.warn("Invalid region configured", { region: regionEnv, valid: ["us", "eu", "oc", "ca", "us2", "fed"] });
     return null;
   }
 
@@ -54,7 +54,7 @@ export async function getClient(): Promise<NinjaOneClient> {
 
   if (!creds) {
     throw new Error(
-      "No API credentials provided. Please configure NINJAONE_CLIENT_ID, NINJAONE_CLIENT_SECRET, and optionally NINJAONE_REGION (us, eu, oc) environment variables."
+      "No API credentials provided. Please configure NINJAONE_CLIENT_ID, NINJAONE_CLIENT_SECRET, and optionally NINJAONE_REGION (us, eu, oc, ca, us2, fed) environment variables."
     );
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -44,13 +44,13 @@ export function isDomainName(value: string): value is DomainName {
 /**
  * NinjaOne region type
  */
-export type NinjaOneRegion = "us" | "eu" | "oc";
+export type NinjaOneRegion = "us" | "eu" | "oc" | "ca" | "us2" | "fed";
 
 /**
  * Check if a string is a valid NinjaOne region
  */
 export function isValidRegion(value: string): value is NinjaOneRegion {
-  return ["us", "eu", "oc"].includes(value);
+  return ["us", "eu", "oc", "ca", "us2", "fed"].includes(value);
 }
 
 /**
@@ -62,6 +62,12 @@ export function getBaseUrlForRegion(region: NinjaOneRegion): string {
       return "https://eu.ninjarmm.com";
     case "oc":
       return "https://oc.ninjarmm.com";
+    case "ca":
+      return "https://ca.ninjarmm.com";
+    case "us2":
+      return "https://us2.ninjarmm.com";
+    case "fed":
+      return "https://fed.ninjarmm.com";
     case "us":
     default:
       return "https://app.ninjarmm.com";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,7 +5,7 @@
  * Credentials are expected via gateway headers:
  * - X-Ninja-Client-ID
  * - X-Ninja-Client-Secret
- * - X-Ninja-Region (optional, defaults to "us")
+ * - X-Ninja-Region (optional, defaults to "us"; valid: us, eu, oc, ca, us2, fed)
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";


### PR DESCRIPTION
## Summary
- Add `ca` (Canada), `us2` (US2), and `fed` (Federal) to the `NinjaOneRegion` type, `isValidRegion()`, and `getBaseUrlForRegion()`
- Update all user-facing messages (client errors, manifest description, code comments) to list all six valid regions
- Add test coverage for new regions in `types.test.ts`

Closes #3

## Test plan
- [ ] Run `npm test` to verify new region validation and URL resolution tests pass
- [ ] Verify `NINJAONE_REGION=ca` resolves to `https://ca.ninjarmm.com`
- [ ] Verify `NINJAONE_REGION=us2` resolves to `https://us2.ninjarmm.com`
- [ ] Verify `NINJAONE_REGION=fed` resolves to `https://fed.ninjarmm.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)