### PR TITLE
feat: publish to MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "ERROR: needs.release.outputs.version is empty" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -127,6 +137,42 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Stamp version into server.json
+        run: |
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/ninjaone-mcp:v" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+      - name: Verify registry listing
+        run: |
+          sleep 5
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/ninjaone-mcp" \
+            | jq '.servers[]?.server | {name, version}'
+
   deploy:
     name: Deploy to Azure Container Apps
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,3 +90,4 @@ LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology
 LABEL org.opencontainers.image.url="https://github.com/wyre-technology/ninjaone-mcp/pkgs/container/ninjaone-mcp"
 LABEL org.opencontainers.image.vendor="Wyre Technology"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/ninjaone-mcp"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.wyre-technology/ninjaone-mcp",
+  "title": "NinjaOne",
+  "description": "MCP server for NinjaOne RMM — devices, organizations, alerts, and tickets.",
+  "repository": {
+    "url": "https://github.com/wyre-technology/ninjaone-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/wyre-technology/ninjaone-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/wyre-technology/ninjaone-mcp:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "NINJAONE_CLIENT_ID",
+          "description": "NinjaOne OAuth 2.0 Client ID",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "NINJAONE_CLIENT_SECRET",
+          "description": "NinjaOne OAuth 2.0 Client Secret",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "NINJAONE_REGION",
+          "description": "NinjaOne region: 'us' (default), 'eu', or 'oc'",
+          "isRequired": false,
+          "default": "us",
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode for the server. Set to 'stdio' for local CLI use; the image defaults to 'http' for gateway hosting.",
+          "isRequired": false,
+          "default": "stdio",
+          "format": "string"
+        },
+        {
+          "name": "AUTH_MODE",
+          "description": "Credential source: 'env' reads vars locally, 'gateway' expects header injection from the WYRE MCP Gateway.",
+          "isRequired": false,
+          "default": "env",
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error",
+          "isRequired": false,
+          "default": "info",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `server.json` (OCI/stdio, name `io.github.wyre-technology/ninjaone-mcp`) describing required NinjaOne creds and runtime env vars
- Adds `io.modelcontextprotocol.server.name` label to the production Dockerfile stage
- Appends `mcp-registry` job to `release.yml` (GitHub OIDC auth, version stamping, validate, publish, verify) gated on `needs.release.outputs.released == 'true'`
- Replaces docker job's version source with `needs.release.outputs.version` via the standard `Resolve release version` step (avoids package.json read / branch-protection conflicts)

Pattern reference: wyre-technology/autotask-mcp#85, #86.

## Test plan
- [ ] Merge to main triggers `release` -> `docker` -> `mcp-registry` jobs
- [ ] `mcp-registry` validates and publishes `server.json`
- [ ] Registry listing query returns the new entry