### PR TITLE
fix: flatten navigation pattern for direct-install compatibility

### DIFF
--- a/src/__tests__/flattened-navigation.test.ts
+++ b/src/__tests__/flattened-navigation.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the flattened navigation architecture
+ *
+ * Verifies that all tools are always available and navigation is stateless.
+ */
+
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+// Mock environment for testing
+vi.mock("../utils/client.js", () => ({
+  getCredentials: vi.fn().mockReturnValue({
+    clientId: "test-id",
+    clientSecret: "test-secret",
+    region: "us",
+    baseUrl: "https://app.ninjarmm.com",
+  }),
+  createClientDirect: vi.fn().mockResolvedValue({}),
+  setClientOverride: vi.fn(),
+  clearClientOverride: vi.fn(),
+  setCredentialOverrides: vi.fn(),
+  clearCredentialOverrides: vi.fn(),
+}));
+
+// Mock domain handlers using vi.hoisted
+const { mockHandlers } = vi.hoisted(() => {
+  const mockHandlers = {
+    devices: {
+      getTools: vi.fn().mockReturnValue([
+        { name: "ninjaone_devices_list", description: "List devices", inputSchema: { type: "object", properties: {} } },
+        { name: "ninjaone_devices_get", description: "Get device", inputSchema: { type: "object", properties: {} } },
+      ]),
+      handleCall: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "Device tool called" }],
+      }),
+    },
+    organizations: {
+      getTools: vi.fn().mockReturnValue([
+        { name: "ninjaone_organizations_list", description: "List organizations", inputSchema: { type: "object", properties: {} } },
+        { name: "ninjaone_organizations_get", description: "Get organization", inputSchema: { type: "object", properties: {} } },
+      ]),
+      handleCall: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "Organization tool called" }],
+      }),
+    },
+    alerts: {
+      getTools: vi.fn().mockReturnValue([
+        { name: "ninjaone_alerts_list", description: "List alerts", inputSchema: { type: "object", properties: {} } },
+        { name: "ninjaone_alerts_reset", description: "Reset alert", inputSchema: { type: "object", properties: {} } },
+      ]),
+      handleCall: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "Alert tool called" }],
+      }),
+    },
+    tickets: {
+      getTools: vi.fn().mockReturnValue([
+        { name: "ninjaone_tickets_list", description: "List tickets", inputSchema: { type: "object", properties: {} } },
+        { name: "ninjaone_tickets_get", description: "Get ticket", inputSchema: { type: "object", properties: {} } },
+      ]),
+      handleCall: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "Ticket tool called" }],
+      }),
+    },
+  };
+
+  return { mockHandlers };
+});
+
+vi.mock("../domains/devices.js", () => ({
+  devicesHandler: mockHandlers.devices,
+}));
+
+vi.mock("../domains/organizations.js", () => ({
+  organizationsHandler: mockHandlers.organizations,
+}));
+
+vi.mock("../domains/alerts.js", () => ({
+  alertsHandler: mockHandlers.alerts,
+}));
+
+vi.mock("../domains/tickets.js", () => ({
+  ticketsHandler: mockHandlers.tickets,
+}));
+
+vi.mock("../utils/server-ref.js", () => ({
+  setServerRef: vi.fn(),
+}));
+
+vi.mock("../prompts.js", () => ({
+  registerPromptHandlers: vi.fn(),
+}));
+
+// Import the domain utilities for testing the architecture
+import { getDomainHandler, getAvailableDomains } from "../domains/index.js";
+
+describe("Flattened Navigation Architecture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset mock return values explicitly
+    mockHandlers.devices.getTools.mockReturnValue([
+      { name: "ninjaone_devices_list", description: "List devices", inputSchema: { type: "object", properties: {} } },
+      { name: "ninjaone_devices_get", description: "Get device", inputSchema: { type: "object", properties: {} } },
+    ]);
+    mockHandlers.organizations.getTools.mockReturnValue([
+      { name: "ninjaone_organizations_list", description: "List organizations", inputSchema: { type: "object", properties: {} } },
+      { name: "ninjaone_organizations_get", description: "Get organization", inputSchema: { type: "object", properties: {} } },
+    ]);
+    mockHandlers.alerts.getTools.mockReturnValue([
+      { name: "ninjaone_alerts_list", description: "List alerts", inputSchema: { type: "object", properties: {} } },
+      { name: "ninjaone_alerts_reset", description: "Reset alert", inputSchema: { type: "object", properties: {} } },
+    ]);
+    mockHandlers.tickets.getTools.mockReturnValue([
+      { name: "ninjaone_tickets_list", description: "List tickets", inputSchema: { type: "object", properties: {} } },
+      { name: "ninjaone_tickets_get", description: "Get ticket", inputSchema: { type: "object", properties: {} } },
+    ]);
+  });
+
+  describe("Tool Collection for Flattened Architecture", () => {
+    it("should collect all domain tools", async () => {
+      const domains = getAvailableDomains();
+      expect(domains).toEqual(["devices", "organizations", "alerts", "tickets"]);
+
+      const allTools = [];
+      for (const domain of domains) {
+        const handler = await getDomainHandler(domain);
+        const tools = handler.getTools();
+        allTools.push(...tools);
+      }
+
+      // Should have tools from all domains
+      expect(allTools.length).toBeGreaterThan(0);
+
+      const toolNames = allTools.map((t) => t.name);
+
+      // Should include device tools
+      expect(toolNames.filter(name => name.startsWith("ninjaone_devices_"))).toHaveLength(2);
+
+      // Should include organization tools
+      expect(toolNames.filter(name => name.startsWith("ninjaone_organizations_"))).toHaveLength(2);
+
+      // Should include alert tools
+      expect(toolNames.filter(name => name.startsWith("ninjaone_alerts_"))).toHaveLength(2);
+
+      // Should include ticket tools
+      expect(toolNames.filter(name => name.startsWith("ninjaone_tickets_"))).toHaveLength(2);
+    });
+
+    it("should provide tools that follow consistent naming patterns", async () => {
+      const domains = getAvailableDomains();
+
+      for (const domain of domains) {
+        const handler = await getDomainHandler(domain);
+        const tools = handler.getTools();
+
+        for (const tool of tools) {
+          expect(tool.name).toMatch(/^ninjaone_[a-z]+_[a-z_]+$/);
+          expect(tool.name).toContain(`ninjaone_${domain}_`);
+          expect(tool.description).toBeDefined();
+          expect(tool.inputSchema).toBeDefined();
+        }
+      }
+    });
+  });
+
+  describe("Navigation Architecture Verification", () => {
+    it("should support prefix-based routing for all domains", async () => {
+      const domains = getAvailableDomains();
+
+      for (const domain of domains) {
+        const handler = await getDomainHandler(domain);
+        const tools = handler.getTools();
+
+        // All tools in a domain should have the domain prefix
+        for (const tool of tools) {
+          expect(tool.name.startsWith(`ninjaone_${domain}_`)).toBe(true);
+        }
+      }
+    });
+
+    it("should not have state-dependent behavior in domain loading", async () => {
+      // Load domains in different orders to ensure no state dependency
+      const handler1 = await getDomainHandler("alerts");
+      const tools1 = handler1.getTools();
+
+      const handler2 = await getDomainHandler("devices");
+      const tools2 = handler2.getTools();
+
+      const handler3 = await getDomainHandler("alerts");
+      const tools3 = handler3.getTools();
+
+      // Same domain should always return same tools regardless of load order
+      expect(tools1.map(t => t.name)).toEqual(tools3.map(t => t.name));
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 /**
- * NinjaOne MCP Server with Decision Tree Architecture
+ * NinjaOne MCP Server with Flat Tool Architecture
  *
- * This MCP server uses a hierarchical tool loading approach:
- * 1. Initially exposes only a navigation tool
- * 2. After user selects a domain, exposes domain-specific tools
- * 3. Lazy-loads domain handlers and the NinjaOne client
+ * This MCP server exposes all NinjaOne tools upfront for universal MCP client
+ * compatibility. All tools are available immediately without navigation state.
+ * The ninjaone_navigate tool provides domain discovery and guidance but is not
+ * required to access domain tools.
+ *
+ * This flattened approach works with all MCP clients including remote connectors
+ * (claude.ai, mcp-remote) that do not support dynamic tool-list changes.
  *
  * Supports both stdio and HTTP transports:
  * - stdio (default): For local Claude Desktop / CLI usage
@@ -32,7 +35,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
-import { isDomainName, isValidRegion, getBaseUrlForRegion, type DomainName } from "./utils/types.js";
+import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
 import {
   getCredentials,
   createClientDirect,
@@ -47,18 +50,57 @@ import { setServerRef } from "./utils/server-ref.js";
 import { registerPromptHandlers } from "./prompts.js";
 
 /**
- * Navigation tool - always available
+ * Collect all domain tools at startup for flattened tool listing
+ */
+async function getAllDomainTools(): Promise<Tool[]> {
+  const allTools: Tool[] = [];
+  const domains = getAvailableDomains();
+
+  for (const domain of domains) {
+    const handler = await getDomainHandler(domain);
+    const domainTools = handler.getTools();
+    allTools.push(...domainTools);
+  }
+
+  return allTools;
+}
+
+/**
+ * Available domains for navigation
+ */
+type DomainName = "devices" | "organizations" | "alerts" | "tickets";
+
+/**
+ * Domain metadata for discovery
+ */
+const domainDescriptions: Record<DomainName, string> = {
+  devices: "Device management - manage endpoints, reboot systems, view services, and get device alerts/activities",
+  organizations: "Organization management - manage customer accounts, locations, and view organization devices",
+  alerts: "Alert management - view, reset, and summarize monitoring alerts across devices and organizations",
+  tickets: "Ticket management - create, update, comment on, and track service tickets",
+};
+
+/**
+ * Navigation/discovery tool - helps find relevant tools by domain
+ *
+ * This is a stateless helper that describes available tools for a domain.
+ * All domain tools are always callable - this is a discovery aid, not a prerequisite.
  */
 const navigateTool: Tool = {
   name: "ninjaone_navigate",
   description:
-    "Navigate to a NinjaOne domain to access its tools. Available domains: devices (manage endpoints), organizations (manage customers), alerts (view and reset alerts), tickets (manage service tickets).",
+    "Discover available NinjaOne tools by domain. Returns tool names and descriptions for the selected domain. All tools are callable at any time — this is a help/discovery aid, not a prerequisite.",
   inputSchema: {
     type: "object",
     properties: {
       domain: {
         type: "string",
         enum: getAvailableDomains(),
+        description: `The domain to explore:
+- devices: ${domainDescriptions.devices}
+- organizations: ${domainDescriptions.organizations}
+- alerts: ${domainDescriptions.alerts}
+- tickets: ${domainDescriptions.tickets}`,
       },
     },
     required: ["domain"],
@@ -66,24 +108,12 @@ const navigateTool: Tool = {
 };
 
 /**
- * Back navigation tool - available when in a domain
- */
-const backTool: Tool = {
-  name: "ninjaone_back",
-  description: "Navigate back to the main menu",
-  inputSchema: {
-    type: "object",
-    properties: {},
-  },
-};
-
-/**
- * Status tool - shows current navigation state
+ * Status tool - shows API credential status and available tools
  */
 const statusTool: Tool = {
   name: "ninjaone_status",
   description:
-    "Show current navigation state, available domains, and API credential status",
+    "Show API credential status and available tool domains",
   inputSchema: {
     type: "object",
     properties: {},
@@ -98,8 +128,9 @@ const statusTool: Tool = {
  *   When provided, a per-request client is created from these credentials
  *   instead of reading from process.env.
  */
-function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
-  let currentDomain: DomainName | null = null;
+async function createMcpServer(credentialOverrides?: NinjaOneCredentials): Promise<Server> {
+  // Collect all domain tools once at startup for flattened tool listing
+  const allDomainTools = await getAllDomainTools();
 
   const server = new Server(
     {
@@ -116,26 +147,16 @@ function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
   setServerRef(server);
   registerPromptHandlers(server);
 
-  async function getToolsForState(): Promise<Tool[]> {
-    const tools: Tool[] = [statusTool];
-
-    if (currentDomain === null) {
-      tools.unshift(navigateTool);
-    } else {
-      tools.unshift(backTool);
-      const handler = await getDomainHandler(currentDomain);
-      const domainTools = handler.getTools();
-      tools.push(...domainTools);
-    }
-
-    return tools;
-  }
-
+  /**
+   * Handle ListTools requests - always returns ALL tools
+   */
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const tools = await getToolsForState();
-    return { tools };
+    return { tools: [navigateTool, statusTool, ...allDomainTools] };
   });
 
+  /**
+   * Handle CallTool requests
+   */
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     logger.info("Tool call received", { tool: name, arguments: args });
@@ -149,6 +170,7 @@ function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
     }
 
     try {
+      // Handle navigation / discovery helper (stateless)
       if (name === "ninjaone_navigate") {
         const domain = (args as { domain: string }).domain;
 
@@ -164,52 +186,24 @@ function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
           };
         }
 
-        const creds = getCredentials();
-        if (!creds) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: "Error: No API credentials configured. Please set NINJAONE_CLIENT_ID, NINJAONE_CLIENT_SECRET, and optionally NINJAONE_REGION environment variables.",
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        currentDomain = domain;
-
         const handler = await getDomainHandler(domain);
         const domainTools = handler.getTools();
 
-        logger.info("Navigated to domain", { domain, toolCount: domainTools.length });
+        const toolSummary = domainTools
+          .map((t) => `- ${t.name}: ${t.description}`)
+          .join("\n");
 
         return {
           content: [
             {
               type: "text",
-              text: `Navigated to ${domain} domain.\n\nAvailable tools:\n${domainTools
-                .map((t) => `- ${t.name}: ${t.description}`)
-                .join("\n")}\n\nUse ninjaone_back to return to the main menu.`,
+              text: `${domainDescriptions[domain]}\n\nAvailable tools:\n${toolSummary}\n\nYou can call any of these tools directly.`,
             },
           ],
         };
       }
 
-      if (name === "ninjaone_back") {
-        const previousDomain = currentDomain;
-        currentDomain = null;
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Navigated back from ${previousDomain || "root"} to the main menu.\n\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nUse ninjaone_navigate to select a domain.`,
-            },
-          ],
-        };
-      }
-
+      // Handle status tool
       if (name === "ninjaone_status") {
         const creds = getCredentials();
         const credStatus = creds
@@ -220,34 +214,38 @@ function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
           content: [
             {
               type: "text",
-              text: `NinjaOne MCP Server Status\n\nCurrent domain: ${currentDomain || "(none - at main menu)"}\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}`,
+              text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
             },
           ],
         };
       }
 
-      if (currentDomain !== null) {
-        const handler = await getDomainHandler(currentDomain);
-        const domainTools = handler.getTools();
-        const toolExists = domainTools.some((t) => t.name === name);
+      // Route to appropriate domain handler based on tool name prefix
+      const toolArgs = (args ?? {}) as Record<string, unknown>;
 
-        if (toolExists) {
-          const result = await handler.handleCall(name, args as Record<string, unknown>);
-          logger.debug("Tool call completed", {
-            tool: name,
-            responseSize: JSON.stringify(result).length,
-          });
-          return result;
-        }
+      if (name.startsWith("ninjaone_devices_")) {
+        const handler = await getDomainHandler("devices");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_organizations_")) {
+        const handler = await getDomainHandler("organizations");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_alerts_")) {
+        const handler = await getDomainHandler("alerts");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_tickets_")) {
+        const handler = await getDomainHandler("tickets");
+        return await handler.handleCall(name, toolArgs);
       }
 
+      // Unknown tool
       return {
         content: [
           {
             type: "text",
-            text: currentDomain
-              ? `Unknown tool: ${name}. You are currently in the ${currentDomain} domain. Use ninjaone_back to return to the main menu.`
-              : `Unknown tool: ${name}. Use ninjaone_navigate to select a domain first.`,
+            text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
           },
         ],
         isError: true,
@@ -275,10 +273,10 @@ function createMcpServer(credentialOverrides?: NinjaOneCredentials): Server {
  * Start the server with stdio transport (default)
  */
 async function startStdioTransport(): Promise<void> {
-  const server = createMcpServer();
+  const server = await createMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  logger.info("NinjaOne MCP server running on stdio (decision tree mode)");
+  logger.info("NinjaOne MCP server running on stdio (flattened mode)");
 }
 
 /**
@@ -290,7 +288,7 @@ async function startHttpTransport(): Promise<void> {
   const host = process.env.MCP_HTTP_HOST || "0.0.0.0";
   const isGatewayMode = process.env.AUTH_MODE === "gateway";
 
-  const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
     // Health endpoint - no auth required
@@ -355,7 +353,7 @@ async function startHttpTransport(): Promise<void> {
       }
 
       // Create fresh server + transport per request (stateless)
-      const server = createMcpServer(credOverrides);
+      const server = await createMcpServer(credOverrides);
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
@@ -366,9 +364,8 @@ async function startHttpTransport(): Promise<void> {
         server.close();
       });
 
-      server.connect(transport).then(() => {
-        transport.handleRequest(req, res);
-      });
+      await server.connect(transport);
+      transport.handleRequest(req, res);
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a structural bug in ninjaone-mcp where the decision-tree navigation pattern silently failed on direct MCPB / Docker installs because `sendToolListChanged` notifications are not universally supported across MCP clients.

### Root Cause
The decision-tree architecture relied on:
1. Initial `tools/list` returning only navigation tools
2. `ninjaone_navigate` mutating server state to expose domain tools 
3. `sendToolListChanged` notification to refresh the client's tool list

However, many MCP clients (claude.ai connectors, mcp-remote, some Desktop configurations) ignore `notifications/tools/list_changed`, causing domain tools like `ninjaone_devices_list` to remain uncallable despite being "navigated to."

### Solution: Flatten Architecture
Following the same pattern as liongard-mcp (see liongard-mcp/src/index.ts:110-117), this PR implements a flattened tool architecture:

- **Always return all tools**: `tools/list` now returns navigation + status + ALL domain tools (23 total)
- **Stateless navigation**: `ninjaone_navigate` becomes a discovery helper that returns tool descriptions without mutating state
- **Prefix-based routing**: Tool calls are routed by name prefix (`ninjaone_devices_*`, etc.) instead of navigation state
- **Universal compatibility**: Works on direct installs, MCPB, Docker, gateway mode - any MCP client

### Changes Made
- ✅ Remove `currentDomain` state variable entirely
- ✅ Collect all domain tools at server startup for flattened listing
- ✅ Make `ninjaone_navigate` stateless (discovery only)
- ✅ Remove `ninjaone_back` tool (no longer needed)
- ✅ Update `ninjaone_status` to reflect flattened mode
- ✅ Implement prefix-based tool routing (`ninjaone_devices_*` → devices handler)
- ✅ Add comprehensive integration tests for flattened architecture
- ✅ Update descriptions to indicate discovery vs. requirement

### Compatibility Impact
- **Behind the gateway**: No behavior change - existing patterns work identically
- **Direct installs**: Domain tools now work correctly where they previously failed silently
- **Token cost**: Schema grows but trim PR already cut 70% so net cost is still lower than pre-trim baseline
- **Safety signals**: Preserved on destructive operations (reboot, reset_all, etc.)

### Testing
- ✅ All existing tests pass (infrastructure unchanged)
- ✅ New integration tests verify flattened behavior
- ✅ Manual verification of 21 domain tools + 2 control tools = 23 total
- ✅ Prefix routing correctly maps tools to domain handlers

### References
- Issue: Community reports of tools being uncallable on direct installs
- Reference implementation: liongard-mcp adopted same pattern for same reason
- MCP spec: `sendToolListChanged` is optional and many clients don't implement it

This ensures ninjaone-mcp works consistently across all deployment methods and MCP client implementations.