### PR TITLE
fix: shallow unauthenticated /health probe for gateway mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Fixed
+
+- `GET /health` (and new `/healthz`) is now a shallow, unauthenticated liveness
+  probe that always returns `200 {"status":"ok"}`. It no longer calls
+  `getCredentials()`. In gateway mode (`AUTH_MODE=gateway`) credentials only
+  arrive per-request via headers, so the previous credential check made
+  `/health` always return `503`, failing the Azure Container Apps liveness
+  probe and crash-looping the container.
+
 ## [1.4.2](https://github.com/wyre-technology/ninjaone-mcp/compare/v1.4.1...v1.4.2) (2026-04-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wyre-technology/ninjaone-mcp",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "NinjaOne MCP server with decision tree architecture for Claude",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/flattened-navigation.test.ts
+++ b/src/__tests__/flattened-navigation.test.ts
@@ -4,12 +4,7 @@
  * Verifies that all tools are always available and navigation is stateless.
  */
 
-import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock environment for testing
 vi.mock("../utils/client.js", () => ({
@@ -194,6 +189,8 @@ describe("Flattened Navigation Architecture", () => {
 
       // Same domain should always return same tools regardless of load order
       expect(tools1.map(t => t.name)).toEqual(tools3.map(t => t.name));
+      // A different domain returns a different tool set
+      expect(tools2.map(t => t.name)).not.toEqual(tools1.map(t => t.name));
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,29 +291,13 @@ async function startHttpTransport(): Promise<void> {
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
-    // Health endpoint - no auth required
-    if (url.pathname === "/health") {
-      const creds = getCredentials();
-      const status = creds ? "ok" : "degraded";
-      const statusCode = creds ? 200 : 503;
-
-      res.writeHead(statusCode, { "Content-Type": "application/json" });
-      res.end(
-        JSON.stringify({
-          status,
-          transport: "http",
-          authMode: isGatewayMode ? "gateway" : "env",
-          timestamp: new Date().toISOString(),
-          credentials: {
-            configured: !!creds,
-            region: creds?.region ?? null,
-            hasClientId: !!process.env.NINJAONE_CLIENT_ID,
-            hasClientSecret: !!process.env.NINJAONE_CLIENT_SECRET,
-          },
-          logLevel: process.env.LOG_LEVEL || "info",
-          version: "1.0.0",
-        })
-      );
+    // Health endpoint - shallow, unauthenticated liveness probe.
+    // Must NOT call getCredentials() or any upstream: in gateway mode
+    // credentials only arrive per-request via headers, so a credential
+    // check here would always 503 and crash-loop the container.
+    if (url.pathname === "/health" || url.pathname === "/healthz") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok" }));
       return;
     }
 


### PR DESCRIPTION
## Problem

`gwp-ninjaone` was crash-looping in production. The container booted fine, then logged `[WARN] Missing credentials {"hasClientId":false,"hasClientSecret":false}` every ~15-30s followed by `[INFO] Shutting down...`.

**Root cause:** `GET /health` ran credential-checking logic — it called `getCredentials()` and returned HTTP `503` when no process-wide credentials were set. In gateway mode (`AUTH_MODE=gateway`) credentials only arrive per-request via headers, so `/health` always 503'd. The Azure Container Apps liveness probe (`GET /health`, every 30s) failed and Azure SIGTERM-killed the container.

This is the identical bug already fixed in mimecast-mcp, ironscales-mcp, spamtitan-mcp and threatlocker-mcp.

## Fix

Make `/health` (and new `/healthz`) a shallow, unauthenticated liveness probe at the top of the request handler that always returns `200 {"status":"ok"}` — no `getCredentials()` call, no upstream calls.

## Testing

- `npm run build` passes (tsc clean).
- Local smoke test with `AUTH_MODE=gateway` (no credentials): `/health` → `200`, `/healthz` → `200`, body `{"status":"ok"}`.
- Deployed `ghcr.io/wyre-technology/ninjaone-mcp:1.4.3` to `gwp-ninjaone`; new revision `gwp-ninjaone--0000001` is **Healthy / RunningAtMaxScale**, no more crash loop.

Version bumped 1.4.2 → 1.4.3.