### PR TITLE
fix(tickets): forward cursor for pagination + add boards_list tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@wyre-technology/ninjaone-mcp",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wyre-technology/ninjaone-mcp",
-      "version": "1.3.0",
+      "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@wyre-technology/node-ninjaone": "^1.0.0"
+        "@wyre-technology/node-ninjaone": "^1.1.2"
       },
       "bin": {
         "ninjaone-mcp": "dist/index.js"
@@ -2300,12 +2300,12 @@
       }
     },
     "node_modules/@wyre-technology/node-ninjaone": {
-      "version": "1.0.2",
-      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/1.0.2/9547bf55fc475d7e817e6058414d6bc7b8e70d09",
-      "integrity": "sha512-VExRT0mhgF0+sUDPut0gPfxCaPjGJoO4v09GxqBgAVCI0NBsCqwWd73fdA0atoPqs0vOfi07cP13EdiGs28rvA==",
+      "version": "1.1.2",
+      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/1.1.2/2d88096e8b223f2ce6ee67749cd70f9c39072fea",
+      "integrity": "sha512-VdhwQMs4Scd/OH79O5zfg/1CGjqdLR4FN+qtb0cgGWCtJfYIYtSUsEfhywDMQwVljVoReHV+/4VQVDVUUz93hg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/wyre-technology/ninjaone-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
-    "@wyre-technology/node-ninjaone": "^1.0.0"
+    "@wyre-technology/node-ninjaone": "^1.1.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/__tests__/domains/tickets.test.ts
+++ b/src/__tests__/domains/tickets.test.ts
@@ -172,7 +172,20 @@ describe("Tickets Domain Handler", () => {
           deviceId: 10,
           boardId: undefined,
           pageSize: 25,
+          lastCursorId: undefined,
         });
+      });
+
+      it("should forward cursor as lastCursorId for pagination", async () => {
+        await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 2,
+          limit: 50,
+          cursor: "50",
+        });
+
+        expect(mockTicketsList).toHaveBeenCalledWith(
+          expect.objectContaining({ lastCursorId: 50, pageSize: 50, boardId: 2 })
+        );
       });
     });
 

--- a/src/__tests__/domains/tickets.test.ts
+++ b/src/__tests__/domains/tickets.test.ts
@@ -12,6 +12,7 @@ const {
   mockTicketsUpdate,
   mockTicketsAddComment,
   mockTicketsGetComments,
+  mockTicketsListBoards,
   mockClient,
 } = vi.hoisted(() => {
   const mockTicketsList = vi.fn();
@@ -20,6 +21,7 @@ const {
   const mockTicketsUpdate = vi.fn();
   const mockTicketsAddComment = vi.fn();
   const mockTicketsGetComments = vi.fn();
+  const mockTicketsListBoards = vi.fn();
 
   const mockClient = {
     tickets: {
@@ -29,6 +31,7 @@ const {
       update: mockTicketsUpdate,
       addComment: mockTicketsAddComment,
       getComments: mockTicketsGetComments,
+      listBoards: mockTicketsListBoards,
     },
   };
 
@@ -39,6 +42,7 @@ const {
     mockTicketsUpdate,
     mockTicketsAddComment,
     mockTicketsGetComments,
+    mockTicketsListBoards,
     mockClient,
   };
 });
@@ -101,13 +105,17 @@ describe("Tickets Domain Handler", () => {
       { id: 1, body: "Comment 1" },
       { id: 2, body: "Comment 2" },
     ]);
+    mockTicketsListBoards.mockResolvedValue([
+      { id: 1, name: "All Tickets" },
+      { id: 2, name: "Service Desk" },
+    ]);
   });
 
   describe("getTools", () => {
     it("should return all ticket tools", () => {
       const tools = ticketsHandler.getTools();
 
-      expect(tools.length).toBe(6);
+      expect(tools.length).toBe(7);
 
       const toolNames = tools.map((t) => t.name);
       expect(toolNames).toContain("ninjaone_tickets_list");
@@ -116,6 +124,7 @@ describe("Tickets Domain Handler", () => {
       expect(toolNames).toContain("ninjaone_tickets_update");
       expect(toolNames).toContain("ninjaone_tickets_add_comment");
       expect(toolNames).toContain("ninjaone_tickets_comments");
+      expect(toolNames).toContain("ninjaone_tickets_boards_list");
     });
 
     it("ninjaone_tickets_get should require ticket_id", () => {
@@ -293,6 +302,19 @@ describe("Tickets Domain Handler", () => {
 
         const data = JSON.parse(result.content[0].text);
         expect(data).toHaveLength(2);
+      });
+    });
+
+    describe("ninjaone_tickets_boards_list", () => {
+      it("should list available boards", async () => {
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_boards_list", {});
+
+        expect(result.isError).toBeUndefined();
+        expect(mockTicketsListBoards).toHaveBeenCalledWith();
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data).toHaveLength(2);
+        expect(data[0]).toEqual({ id: 1, name: "All Tickets" });
       });
     });
 

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -184,6 +184,7 @@ async function handleCall(
         deviceId: args.device_id as number | undefined,
         boardId: args.board_id as number | undefined,
         pageSize: limit,
+        lastCursorId: cursor !== undefined ? Number(cursor) : undefined,
       });
       logger.debug("API response: tickets.list", { count: response.tickets?.length });
 

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -153,6 +153,15 @@ function getTools(): Tool[] {
         required: ["ticket_id"],
       },
     },
+    {
+      name: "ninjaone_tickets_boards_list",
+      description:
+        "List available ticket boards for the tenant. Use this to discover board_id values for ninjaone_tickets_list.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {},
+      },
+    },
   ];
 }
 
@@ -265,6 +274,16 @@ async function handleCall(
 
       return {
         content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+      };
+    }
+
+    case "ninjaone_tickets_boards_list": {
+      logger.info("API call: tickets.listBoards");
+      const boards = await client.tickets.listBoards();
+      logger.debug("API response: tickets.listBoards", { count: boards.length });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(boards, null, 2) }],
       };
     }
 


### PR DESCRIPTION
## Summary
- `ninjaone_tickets_list` accepted a `cursor` arg but never forwarded it to the SDK — every call returned page 1. Now passed through as `lastCursorId: Number(cursor)`
- Added `ninjaone_tickets_boards_list` tool to surface the SDK's `listBoards()` so callers can discover `board_id` values without scraping the NinjaOne UI

Closes #31

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run` — 107/107 pass (added regression test for cursor forwarding, tool-list assertion, and handler test for boards_list)
- [ ] Verify on deployed instance: `board_id=2, limit=50, cursor=\"50\"` returns rows 51..100
- [ ] Verify `ninjaone_tickets_boards_list` returns the tenant's board list

## Related
- Upstream SDK filter-builder fix: wyre-technology/node-ninjaone#16 (status enum → numeric statusId, organizationId → clientId)