### PR TITLE
fix(ci): gate docker/deploy on actual release to stop :latest tag regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,11 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     needs: [test, release]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Gate on an actual semantic-release. A non-release push to main would
+    # otherwise rebuild and re-push :latest tagged with the stale package.json
+    # version, clobbering the correctly-tagged :latest from the last real
+    # release. Skipping docker cascades to deploy/registry (skipped dependency).
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # The push digest is the only race-proof way to deploy this exact build.
+      # `:latest` is mutable and can resolve to a stale layer; the digest is
+      # bulletproof and is what the reusable deploy workflow pins on.
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -121,6 +126,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
+        id: push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
         with:
           context: .
@@ -171,28 +177,15 @@ jobs:
 
   deploy:
     name: Deploy to Azure Container Apps
-    runs-on: ubuntu-latest
-    needs: [docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    environment: production
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Azure login (OIDC)
-        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5  # v2.3.0
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Deploy to Azure Container Apps
-        run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          IMAGE="ghcr.io/${{ github.repository }}:latest"
-          echo "Deploying $IMAGE to mcpgw-prod-ninjaone (revision tag sha-${SHORT_SHA}-${GITHUB_RUN_ID})"
-          az containerapp update \
-            --name mcpgw-prod-ninjaone \
-            --resource-group mcp-gateway-prod \
-            --image "$IMAGE" \
-            --set-env-vars "IMAGE_VERSION=sha-${SHORT_SHA}-${GITHUB_RUN_ID}"
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@d6ace529b210900f460cb365529f2a552daedf7a
+    with:
+      vendor-slug: ninjaone
+      image-name: ghcr.io/wyre-technology/ninjaone-mcp
+      digest: ${{ needs.docker.outputs.digest }}
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

On a **non-release** push to `main` (e.g. docs/chore commits where semantic-release decides not to cut a version), the `docker` job still ran and rebuilt `:latest`. Because this repo has no `@semantic-release/git`, `package.json` still holds the **stale** version, so `:latest` got re-pushed pointing at the old version — clobbering the correctly-tagged `:latest` from the last real release.

## Fix

Gate the `docker` job on an actual semantic-release:

```yaml
if: needs.release.outputs.released == 'true'
```

The job already had `needs: [test, release]`, so the `released` output is available. Skipping `docker` cascades to `deploy` and `mcp-registry` as skipped dependencies — exactly the desired behavior.

No deploy-job changes in this PR.

> [!WARNING]
> The `deploy` job targets `mcpgw-prod-ninjaone` (resource group `mcp-gateway-prod`), **not** `gwp-ninjaone`. If `mcpgw-prod-ninjaone` is the orphaned app, the deploy step is a silent no-op. Flagged for follow-up; intentionally not changed here.
