### PR TITLE
fix(deploy): authenticate GitHub Packages in one-click cloud builds (#33)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -11,6 +11,13 @@ spec:
       instance_count: 1
       instance_size_slug: basic-xxs
       envs:
+        # GitHub PAT (read:packages) used at build time to install the private
+        # @wyre-technology/* dependency from GitHub Packages. Passed to the
+        # Dockerfile's `ARG GITHUB_TOKEN`. Set this as an encrypted SECRET in the
+        # App Platform UI before the first deploy, or the build fails with npm 401.
+        - key: GITHUB_TOKEN
+          scope: BUILD_TIME
+          type: SECRET
         - key: NINJAONE_CLIENT_ID
           scope: RUN_TIME
           type: SECRET

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store
 coverage/
 .npmrc.docker
+graphify-out/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 coverage/
 .npmrc.docker
 graphify-out/
+.wrangler/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,9 @@
+# @wyre-technology/* packages are hosted on the GitHub Packages npm registry.
+# GitHub Packages has no anonymous read: every install needs a token with
+# `read:packages`, even for public packages. The token is read from the
+# NODE_AUTH_TOKEN environment variable so the same .npmrc works in:
+#   - CI (actions/setup-node sets NODE_AUTH_TOKEN)
+#   - one-click deploys (operators set NODE_AUTH_TOKEN as a build variable)
+#   - local dev (run `export NODE_AUTH_TOKEN=$(gh auth token)` once)
 @wyre-technology:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": true
       }
     ],
     "@semantic-release/github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ### Fixed
 
+- One-click deploys (Cloudflare Workers, DigitalOcean App Platform) no longer fail
+  with `npm error 401 Unauthorized ... npm.pkg.github.com` ([#33](https://github.com/wyre-technology/ninjaone-mcp/issues/33)).
+  `.npmrc` now carries an `_authToken=${NODE_AUTH_TOKEN}` line so the cloud builder
+  can authenticate to GitHub Packages, and the README documents the required
+  GitHub PAT (`read:packages`) build variable. `.do/app.yaml` declares a
+  build-time `GITHUB_TOKEN` secret, and the Cloudflare entrypoint now bundles
+  directly from `src/worker.ts`.
+
+### Changed
+
+- The package is now published to the GitHub Packages npm registry
+  (`@semantic-release/npm` `npmPublish: true` + `publishConfig.registry`), so
+  `npm install` / `npx @wyre-technology/ninjaone-mcp` resolve once authenticated.
+
 - `GET /health` (and new `/healthz`) is now a shallow, unauthenticated liveness
   probe that always returns `200 {"status":"ok"}`. It no longer calls
   `getCredentials()`. In gateway mode (`AUTH_MODE=gateway`) credentials only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
   build-time `GITHUB_TOKEN` secret, and the Cloudflare entrypoint now bundles
   directly from `src/worker.ts`.
 
+### Added
+
+- **Cloudflare Workers now serves the full MCP server.** `src/worker.ts` was a
+  placeholder that returned a stub response; it now uses the MCP SDK's
+  `WebStandardStreamableHTTPServerTransport` to serve the complete tool set over
+  `/mcp`, reusing the same `createMcpServer()` factory as the stdio and Node HTTP
+  entrypoints (extracted into `src/mcp-server.ts` — no duplicated tool logic).
+  Supports both env-var credentials and `AUTH_MODE=gateway` header credentials,
+  plus CORS preflight and a `/health` probe. Verified end-to-end on `workerd`
+  (`wrangler dev`): `initialize`, `tools/list` (24 tools), and `tools/call` all
+  return correct JSON-RPC responses.
+
 ### Changed
 
 - The package is now published to the GitHub Packages npm registry

--- a/README.md
+++ b/README.md
@@ -5,9 +5,33 @@ A Model Context Protocol (MCP) server for interacting with NinjaOne, featuring a
 
 ## One-Click Deployment
 
+> [!IMPORTANT]
+> **Before you click:** this server depends on `@wyre-technology/node-ninjaone`,
+> which is hosted on the **GitHub Packages** npm registry. GitHub Packages has no
+> anonymous access — even though the package is public, every `npm install` needs a
+> token. The cloud builder runs `npm install` for you, so you must give it one, or
+> the build fails with `npm error 401 Unauthorized ... npm.pkg.github.com`.
+>
+> 1. Create a GitHub **Personal Access Token** with the `read:packages` scope
+>    ([classic token](https://github.com/settings/tokens/new?scopes=read:packages&description=ninjaone-mcp%20deploy)).
+>    Any GitHub account works — you do **not** need to be a member of the
+>    `wyre-technology` org to read its public packages.
+> 2. Add it as a build variable when prompted by the deploy flow:
+>    - **Cloudflare Workers** → set a build variable named **`NODE_AUTH_TOKEN`** to your PAT
+>      (Workers → Settings → Build → Variables and Secrets).
+>    - **DigitalOcean App Platform** → set an encrypted env var named **`GITHUB_TOKEN`**
+>      with scope **Build Time** to your PAT (the `.do/app.yaml` already declares it).
+
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/wyre-technology/ninjaone-mcp/tree/main)
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wyre-technology/ninjaone-mcp)
+
+> [!NOTE]
+> The DigitalOcean target builds the full Docker image and runs the complete MCP
+> server over HTTP — this is the recommended path for operators. The Cloudflare
+> Workers target is currently a thin entrypoint and is best suited to gateway-style
+> deployments; for a full self-hosted server prefer DigitalOcean or the prebuilt
+> container image (`ghcr.io/wyre-technology/ninjaone-mcp`).
 
 ## Architecture
 
@@ -26,9 +50,21 @@ This architecture provides:
 
 ## Installation
 
+This package is published to the **GitHub Packages** npm registry, which requires a
+token even for public packages. Authenticate once, then install:
+
 ```bash
+# Authenticate npm to GitHub Packages (token needs the read:packages scope)
+export NODE_AUTH_TOKEN=$(gh auth token)   # or a PAT with read:packages
+
 npm install @wyre-technology/ninjaone-mcp
 ```
+
+The repo's `.npmrc` already points the `@wyre-technology` scope at GitHub Packages and
+reads the token from `NODE_AUTH_TOKEN`, so no further config is needed. The same applies
+to `npx @wyre-technology/ninjaone-mcp` below. Prefer a zero-setup option? Use the prebuilt
+container image (`ghcr.io/wyre-technology/ninjaone-mcp`) or the `.mcpb` bundle attached to
+each [release](https://github.com/wyre-technology/ninjaone-mcp/releases).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ A Model Context Protocol (MCP) server for interacting with NinjaOne, featuring a
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/wyre-technology/ninjaone-mcp)
 
 > [!NOTE]
-> The DigitalOcean target builds the full Docker image and runs the complete MCP
-> server over HTTP — this is the recommended path for operators. The Cloudflare
-> Workers target is currently a thin entrypoint and is best suited to gateway-style
-> deployments; for a full self-hosted server prefer DigitalOcean or the prebuilt
-> container image (`ghcr.io/wyre-technology/ninjaone-mcp`).
+> Both targets run the **full** MCP server. DigitalOcean builds the Docker image and
+> serves it over HTTP; Cloudflare Workers serves the same server via the SDK's Web
+> Standard Streamable HTTP transport (`src/worker.ts`). After deploying, set your
+> NinjaOne credentials as secrets — `NINJAONE_CLIENT_ID`, `NINJAONE_CLIENT_SECRET`,
+> and optionally `NINJAONE_REGION` — or set `AUTH_MODE=gateway` to take credentials
+> per-request from `X-Ninja-*` headers. The MCP endpoint is `/mcp`; `/health` is an
+> unauthenticated liveness probe.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the Cloudflare Workers entrypoint.
+ *
+ * Drives the exported `fetch` handler directly with Web Standard Request objects
+ * (available natively in Node 18+), exercising the same WebStandardStreamableHTTP
+ * transport the Worker uses in production.
+ */
+
+import { describe, it, expect } from "vitest";
+import worker, { type Env } from "../worker.js";
+
+const MCP_HEADERS = {
+  Accept: "application/json, text/event-stream",
+  "Content-Type": "application/json",
+};
+
+async function mcp(body: unknown, env: Env = {}): Promise<Response> {
+  return worker.fetch(
+    new Request("http://worker.local/mcp", {
+      method: "POST",
+      headers: MCP_HEADERS,
+      body: JSON.stringify(body),
+    }),
+    env
+  );
+}
+
+describe("Cloudflare Worker entrypoint", () => {
+  it("serves a shallow health probe", async () => {
+    const res = await worker.fetch(new Request("http://worker.local/health"), {});
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+
+  it("answers CORS preflight", async () => {
+    const res = await worker.fetch(
+      new Request("http://worker.local/mcp", { method: "OPTIONS" }),
+      {}
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("404s unknown paths", async () => {
+    const res = await worker.fetch(new Request("http://worker.local/nope"), {});
+    expect(res.status).toBe(404);
+  });
+
+  it("handles MCP initialize", async () => {
+    const res = await mcp({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "vitest", version: "0" },
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+    expect(body.result?.serverInfo?.name).toBe("ninjaone-mcp");
+  });
+
+  it("lists all tools without credentials", async () => {
+    const res = await mcp({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result?: { tools?: { name: string }[] } };
+    const names = (body.result?.tools ?? []).map((t) => t.name);
+    expect(names).toContain("ninjaone_navigate");
+    expect(names).toContain("ninjaone_status");
+    expect(names.length).toBeGreaterThan(10);
+  });
+
+  it("returns a graceful error for a credential-requiring tool when unconfigured", async () => {
+    const res = await mcp({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "ninjaone_devices_list", arguments: {} },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { isError?: boolean; content?: { text?: string }[] };
+    };
+    expect(body.result?.isError).toBe(true);
+    expect(body.result?.content?.[0]?.text).toMatch(/credentials/i);
+  });
+
+  it("rejects /mcp in gateway mode without credential headers", async () => {
+    const res = await mcp(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "ninjaone_devices_list", arguments: {} },
+      },
+      { AUTH_MODE: "gateway" }
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,13 @@
  *
  * This MCP server exposes all NinjaOne tools upfront for universal MCP client
  * compatibility. All tools are available immediately without navigation state.
- * The ninjaone_navigate tool provides domain discovery and guidance but is not
- * required to access domain tools.
- *
- * This flattened approach works with all MCP clients including remote connectors
- * (claude.ai, mcp-remote) that do not support dynamic tool-list changes.
  *
  * Supports both stdio and HTTP transports:
  * - stdio (default): For local Claude Desktop / CLI usage
  * - http: For hosted deployment with optional gateway auth
+ *
+ * The Cloudflare Workers entrypoint lives in `worker.ts` and reuses the same
+ * `createMcpServer()` factory from `mcp-server.ts`.
  *
  * Credentials are provided via environment variables:
  * - NINJAONE_CLIENT_ID
@@ -26,248 +24,14 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
-import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
-import {
-  getCredentials,
-  createClientDirect,
-  setClientOverride,
-  clearClientOverride,
-  setCredentialOverrides,
-  clearCredentialOverrides,
+  createMcpServer,
+  resolveGatewayCredentials,
   type NinjaOneCredentials,
-} from "./utils/client.js";
+} from "./mcp-server.js";
 import { logger } from "./utils/logger.js";
-import { setServerRef } from "./utils/server-ref.js";
-import { registerPromptHandlers } from "./prompts.js";
-
-/**
- * Collect all domain tools at startup for flattened tool listing
- */
-async function getAllDomainTools(): Promise<Tool[]> {
-  const allTools: Tool[] = [];
-  const domains = getAvailableDomains();
-
-  for (const domain of domains) {
-    const handler = await getDomainHandler(domain);
-    const domainTools = handler.getTools();
-    allTools.push(...domainTools);
-  }
-
-  return allTools;
-}
-
-/**
- * Available domains for navigation
- */
-type DomainName = "devices" | "organizations" | "alerts" | "tickets";
-
-/**
- * Domain metadata for discovery
- */
-const domainDescriptions: Record<DomainName, string> = {
-  devices: "Device management - manage endpoints, reboot systems, view services, and get device alerts/activities",
-  organizations: "Organization management - manage customer accounts, locations, and view organization devices",
-  alerts: "Alert management - view, reset, and summarize monitoring alerts across devices and organizations",
-  tickets: "Ticket management - create, update, comment on, and track service tickets",
-};
-
-/**
- * Navigation/discovery tool - helps find relevant tools by domain
- *
- * This is a stateless helper that describes available tools for a domain.
- * All domain tools are always callable - this is a discovery aid, not a prerequisite.
- */
-const navigateTool: Tool = {
-  name: "ninjaone_navigate",
-  description:
-    "Discover available NinjaOne tools by domain. Returns tool names and descriptions for the selected domain. All tools are callable at any time — this is a help/discovery aid, not a prerequisite.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      domain: {
-        type: "string",
-        enum: getAvailableDomains(),
-        description: `The domain to explore:
-- devices: ${domainDescriptions.devices}
-- organizations: ${domainDescriptions.organizations}
-- alerts: ${domainDescriptions.alerts}
-- tickets: ${domainDescriptions.tickets}`,
-      },
-    },
-    required: ["domain"],
-  },
-};
-
-/**
- * Status tool - shows API credential status and available tools
- */
-const statusTool: Tool = {
-  name: "ninjaone_status",
-  description:
-    "Show API credential status and available tool domains",
-  inputSchema: {
-    type: "object",
-    properties: {},
-  },
-};
-
-/**
- * Create a fresh MCP server instance with all handlers registered.
- * Called once for stdio, or per-request for HTTP transport.
- *
- * @param credentialOverrides - Optional credentials for gateway mode.
- *   When provided, a per-request client is created from these credentials
- *   instead of reading from process.env.
- */
-async function createMcpServer(credentialOverrides?: NinjaOneCredentials): Promise<Server> {
-  // Collect all domain tools once at startup for flattened tool listing
-  const allDomainTools = await getAllDomainTools();
-
-  const server = new Server(
-    {
-      name: "ninjaone-mcp",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {},
-        prompts: {},
-      },
-    }
-  );
-  setServerRef(server);
-  registerPromptHandlers(server);
-
-  /**
-   * Handle ListTools requests - always returns ALL tools
-   */
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: [navigateTool, statusTool, ...allDomainTools] };
-  });
-
-  /**
-   * Handle CallTool requests
-   */
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
-    logger.info("Tool call received", { tool: name, arguments: args });
-
-    // If per-request credentials were provided, create an isolated client
-    // and set it as the override so all domain handlers pick it up via getClient().
-    if (credentialOverrides) {
-      setCredentialOverrides(credentialOverrides);
-      const directClient = await createClientDirect(credentialOverrides);
-      setClientOverride(directClient);
-    }
-
-    try {
-      // Handle navigation / discovery helper (stateless)
-      if (name === "ninjaone_navigate") {
-        const domain = (args as { domain: string }).domain;
-
-        if (!isDomainName(domain)) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Invalid domain: ${domain}. Available domains: ${getAvailableDomains().join(", ")}`,
-              },
-            ],
-            isError: true,
-          };
-        }
-
-        const handler = await getDomainHandler(domain);
-        const domainTools = handler.getTools();
-
-        const toolSummary = domainTools
-          .map((t) => `- ${t.name}: ${t.description}`)
-          .join("\n");
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: `${domainDescriptions[domain]}\n\nAvailable tools:\n${toolSummary}\n\nYou can call any of these tools directly.`,
-            },
-          ],
-        };
-      }
-
-      // Handle status tool
-      if (name === "ninjaone_status") {
-        const creds = getCredentials();
-        const credStatus = creds
-          ? `Configured (region: ${creds.region}, base URL: ${creds.baseUrl})`
-          : "NOT CONFIGURED - Please set environment variables";
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
-            },
-          ],
-        };
-      }
-
-      // Route to appropriate domain handler based on tool name prefix
-      const toolArgs = (args ?? {}) as Record<string, unknown>;
-
-      if (name.startsWith("ninjaone_devices_")) {
-        const handler = await getDomainHandler("devices");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_organizations_")) {
-        const handler = await getDomainHandler("organizations");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_alerts_")) {
-        const handler = await getDomainHandler("alerts");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_tickets_")) {
-        const handler = await getDomainHandler("tickets");
-        return await handler.handleCall(name, toolArgs);
-      }
-
-      // Unknown tool
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
-          },
-        ],
-        isError: true,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const stack = error instanceof Error ? error.stack : undefined;
-      logger.error("Tool call failed", { tool: name, error: message, stack });
-      return {
-        content: [{ type: "text", text: `Error: ${message}` }],
-        isError: true,
-      };
-    } finally {
-      if (credentialOverrides) {
-        clearClientOverride();
-        clearCredentialOverrides();
-      }
-    }
-  });
-
-  return server;
-}
 
 /**
  * Start the server with stdio transport (default)
@@ -303,37 +67,24 @@ async function startHttpTransport(): Promise<void> {
 
     // MCP endpoint
     if (url.pathname === "/mcp") {
-      // In gateway mode, extract per-request credentials from headers
-      // and pass them directly to createMcpServer() for isolation.
-      // No process.env mutation — each request gets its own client.
       let credOverrides: NinjaOneCredentials | undefined;
       if (isGatewayMode) {
-        const clientId = req.headers["x-ninja-client-id"] as string | undefined;
-        const clientSecret = req.headers["x-ninja-client-secret"] as string | undefined;
-        const region = req.headers["x-ninja-region"] as string | undefined;
-
-        if (!clientId || !clientSecret) {
+        const { creds, error } = resolveGatewayCredentials(
+          (name) => req.headers[name] as string | undefined
+        );
+        if (error) {
           res.writeHead(401, { "Content-Type": "application/json" });
           res.end(
             JSON.stringify({
               error: "Missing credentials",
-              message:
-                "Gateway mode requires X-Ninja-Client-ID and X-Ninja-Client-Secret headers",
+              message: error,
               required: ["X-Ninja-Client-ID", "X-Ninja-Client-Secret"],
               optional: ["X-Ninja-Region"],
             })
           );
           return;
         }
-
-        const regionVal = (region?.toLowerCase() || "us") as string;
-        const validRegion = isValidRegion(regionVal) ? regionVal : "us" as const;
-        credOverrides = {
-          clientId,
-          clientSecret,
-          region: validRegion,
-          baseUrl: getBaseUrlForRegion(validRegion),
-        };
+        credOverrides = creds;
       }
 
       // Create fresh server + transport per request (stateless)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -35,16 +35,22 @@ export type { NinjaOneCredentials };
 
 /**
  * Collect all domain tools for flattened tool listing.
+ *
+ * The tool set is static and credential-independent, but a fresh server is
+ * created per request (for credential isolation), so the assembled list is
+ * memoized at module scope to avoid rebuilding it on every request.
  */
+let cachedDomainTools: Tool[] | undefined;
 async function getAllDomainTools(): Promise<Tool[]> {
-  const allTools: Tool[] = [];
-  const domains = getAvailableDomains();
+  if (cachedDomainTools) return cachedDomainTools;
 
-  for (const domain of domains) {
+  const allTools: Tool[] = [];
+  for (const domain of getAvailableDomains()) {
     const handler = await getDomainHandler(domain);
     allTools.push(...handler.getTools());
   }
 
+  cachedDomainTools = allTools;
   return allTools;
 }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared MCP server factory for NinjaOne.
+ *
+ * This module is **side-effect free** (importing it never starts a transport),
+ * so it can be reused by every entrypoint:
+ * - `index.ts` — stdio + Node HTTP transport
+ * - `worker.ts` — Cloudflare Workers (Web Standard) transport
+ *
+ * All NinjaOne tools are exposed upfront (flat architecture) for universal MCP
+ * client compatibility.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
+import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
+import {
+  getCredentials,
+  createClientDirect,
+  setClientOverride,
+  clearClientOverride,
+  setCredentialOverrides,
+  clearCredentialOverrides,
+  type NinjaOneCredentials,
+} from "./utils/client.js";
+import { logger } from "./utils/logger.js";
+import { setServerRef } from "./utils/server-ref.js";
+import { registerPromptHandlers } from "./prompts.js";
+
+export type { NinjaOneCredentials };
+
+/**
+ * Collect all domain tools for flattened tool listing.
+ */
+async function getAllDomainTools(): Promise<Tool[]> {
+  const allTools: Tool[] = [];
+  const domains = getAvailableDomains();
+
+  for (const domain of domains) {
+    const handler = await getDomainHandler(domain);
+    allTools.push(...handler.getTools());
+  }
+
+  return allTools;
+}
+
+type DomainName = "devices" | "organizations" | "alerts" | "tickets";
+
+const domainDescriptions: Record<DomainName, string> = {
+  devices:
+    "Device management - manage endpoints, reboot systems, view services, and get device alerts/activities",
+  organizations:
+    "Organization management - manage customer accounts, locations, and view organization devices",
+  alerts:
+    "Alert management - view, reset, and summarize monitoring alerts across devices and organizations",
+  tickets:
+    "Ticket management - create, update, comment on, and track service tickets",
+};
+
+const navigateTool: Tool = {
+  name: "ninjaone_navigate",
+  description:
+    "Discover available NinjaOne tools by domain. Returns tool names and descriptions for the selected domain. All tools are callable at any time — this is a help/discovery aid, not a prerequisite.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      domain: {
+        type: "string",
+        enum: getAvailableDomains(),
+        description: `The domain to explore:
+- devices: ${domainDescriptions.devices}
+- organizations: ${domainDescriptions.organizations}
+- alerts: ${domainDescriptions.alerts}
+- tickets: ${domainDescriptions.tickets}`,
+      },
+    },
+    required: ["domain"],
+  },
+};
+
+const statusTool: Tool = {
+  name: "ninjaone_status",
+  description: "Show API credential status and available tool domains",
+  inputSchema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+/**
+ * Build a validated NinjaOneCredentials object from raw values.
+ * Returns `{ creds }` on success or `{ error }` when client id/secret are missing.
+ * Shared by every transport (Node HTTP headers, Workers headers, Workers env).
+ */
+export function buildCredentials(
+  clientId: string | undefined,
+  clientSecret: string | undefined,
+  region: string | undefined
+): { creds?: NinjaOneCredentials; error?: string } {
+  if (!clientId || !clientSecret) {
+    return {
+      error:
+        "Missing credentials: X-Ninja-Client-ID / X-Ninja-Client-Secret (or NINJAONE_CLIENT_ID / NINJAONE_CLIENT_SECRET)",
+    };
+  }
+
+  const regionVal = region?.toLowerCase() || "us";
+  const validRegion = isValidRegion(regionVal) ? regionVal : "us";
+  return {
+    creds: {
+      clientId,
+      clientSecret,
+      region: validRegion,
+      baseUrl: getBaseUrlForRegion(validRegion),
+    },
+  };
+}
+
+/**
+ * Resolve per-request gateway credentials from a header accessor.
+ *
+ * Works with any transport: pass a getter that returns a (lowercased) header
+ * value. Returns `{ creds }` on success, or `{ error }` when required headers
+ * are missing.
+ */
+export function resolveGatewayCredentials(
+  getHeader: (lowerName: string) => string | undefined
+): { creds?: NinjaOneCredentials; error?: string } {
+  return buildCredentials(
+    getHeader("x-ninja-client-id"),
+    getHeader("x-ninja-client-secret"),
+    getHeader("x-ninja-region")
+  );
+}
+
+/**
+ * Create a fresh MCP server instance with all handlers registered.
+ * Called once for stdio, or per-request for HTTP / Workers transports.
+ *
+ * @param credentialOverrides - Optional credentials for gateway mode. When
+ *   provided, a per-request client is created from these credentials instead of
+ *   reading from process.env.
+ */
+export async function createMcpServer(
+  credentialOverrides?: NinjaOneCredentials
+): Promise<Server> {
+  const allDomainTools = await getAllDomainTools();
+
+  const server = new Server(
+    {
+      name: "ninjaone-mcp",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+        prompts: {},
+      },
+    }
+  );
+  setServerRef(server);
+  registerPromptHandlers(server);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: [navigateTool, statusTool, ...allDomainTools] };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    logger.info("Tool call received", { tool: name, arguments: args });
+
+    if (credentialOverrides) {
+      setCredentialOverrides(credentialOverrides);
+      const directClient = await createClientDirect(credentialOverrides);
+      setClientOverride(directClient);
+    }
+
+    try {
+      if (name === "ninjaone_navigate") {
+        const domain = (args as { domain: string }).domain;
+
+        if (!isDomainName(domain)) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Invalid domain: ${domain}. Available domains: ${getAvailableDomains().join(", ")}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const handler = await getDomainHandler(domain);
+        const domainTools = handler.getTools();
+
+        const toolSummary = domainTools
+          .map((t) => `- ${t.name}: ${t.description}`)
+          .join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${domainDescriptions[domain]}\n\nAvailable tools:\n${toolSummary}\n\nYou can call any of these tools directly.`,
+            },
+          ],
+        };
+      }
+
+      if (name === "ninjaone_status") {
+        const creds = getCredentials();
+        const credStatus = creds
+          ? `Configured (region: ${creds.region}, base URL: ${creds.baseUrl})`
+          : "NOT CONFIGURED - Please set environment variables";
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
+            },
+          ],
+        };
+      }
+
+      const toolArgs = (args ?? {}) as Record<string, unknown>;
+
+      if (name.startsWith("ninjaone_devices_")) {
+        const handler = await getDomainHandler("devices");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_organizations_")) {
+        const handler = await getDomainHandler("organizations");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_alerts_")) {
+        const handler = await getDomainHandler("alerts");
+        return await handler.handleCall(name, toolArgs);
+      }
+      if (name.startsWith("ninjaone_tickets_")) {
+        const handler = await getDomainHandler("tickets");
+        return await handler.handleCall(name, toolArgs);
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
+          },
+        ],
+        isError: true,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error ? error.stack : undefined;
+      logger.error("Tool call failed", { tool: name, error: message, stack });
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    } finally {
+      if (credentialOverrides) {
+        clearClientOverride();
+        clearCredentialOverrides();
+      }
+    }
+  });
+
+  return server;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,158 +1,128 @@
 /**
- * Cloudflare Workers entry point for NinjaOne MCP Server
+ * Cloudflare Workers entry point for the NinjaOne MCP Server.
  *
- * Handles HTTP requests in a serverless environment.
- * Credentials are expected via gateway headers:
- * - X-Ninja-Client-ID
- * - X-Ninja-Client-Secret
- * - X-Ninja-Region (optional, defaults to "us"; valid: us, eu, oc, ca, us2, fed)
+ * Serves the full MCP server over the Streamable HTTP transport using the SDK's
+ * Web Standard transport (Request/Response), which runs natively on Workers.
+ * It reuses the exact same `createMcpServer()` factory as the stdio / Node HTTP
+ * entrypoints (see `mcp-server.ts`), so there is no second tool implementation
+ * to maintain.
+ *
+ * Credentials are resolved per request, in order:
+ * 1. Gateway headers (when AUTH_MODE=gateway):
+ *    - X-Ninja-Client-ID
+ *    - X-Ninja-Client-Secret
+ *    - X-Ninja-Region (optional; us, eu, oc, ca, us2, fed)
+ * 2. Worker secrets / vars (env mode):
+ *    - NINJAONE_CLIENT_ID
+ *    - NINJAONE_CLIENT_SECRET
+ *    - NINJAONE_REGION (optional)
+ *
+ * `tools/list` and `initialize` work without credentials; only `tools/call`
+ * requires them.
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+  createMcpServer,
+  resolveGatewayCredentials,
+  buildCredentials,
+  type NinjaOneCredentials,
+} from "./mcp-server.js";
 
 export interface Env {
   NINJAONE_CLIENT_ID?: string;
   NINJAONE_CLIENT_SECRET?: string;
   NINJAONE_REGION?: string;
+  AUTH_MODE?: string;
+  LOG_LEVEL?: string;
 }
 
-/**
- * Create a fresh MCP server instance for each request
- * Workers are stateless, so we set up the server per-invocation
- */
-function createMcpServer(): Server {
-  const server = new Server(
-    {
-      name: "ninjaone-mcp",
-      version: "1.0.0",
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
-    }
-  );
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, X-Ninja-Client-ID, X-Ninja-Client-Secret, X-Ninja-Region",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+};
 
-  // Register minimal tool listing handler for worker context
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const navigateTool: Tool = {
-      name: "ninjaone_navigate",
-      description:
-        "Navigate to a NinjaOne domain to access its tools. Available domains: devices, organizations, alerts, tickets.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          domain: {
-            type: "string",
-            enum: ["devices", "organizations", "alerts", "tickets"],
-            description: "The domain to navigate to",
-          },
-        },
-        required: ["domain"],
-      },
-    };
-
-    const statusTool: Tool = {
-      name: "ninjaone_status",
-      description: "Show current navigation state and verify API credentials.",
-      inputSchema: {
-        type: "object",
-        properties: {},
-      },
-    };
-
-    return { tools: [navigateTool, statusTool] };
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
   });
+}
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name } = request.params;
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Tool ${name} called in worker context. Full domain handling available in HTTP transport mode.`,
-        },
-      ],
-    };
-  });
-
-  return server;
+function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) headers.set(k, v);
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // Health endpoint
-    if (url.pathname === "/health") {
-      return new Response(
-        JSON.stringify({
-          status: "ok",
-          transport: "cloudflare-workers",
-          timestamp: new Date().toISOString(),
-        }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
 
-    // MCP endpoint
-    if (url.pathname === "/mcp") {
-      // Extract credentials from headers or env
-      const clientId =
-        request.headers.get("x-ninja-client-id") || env.NINJAONE_CLIENT_ID;
-      const clientSecret =
-        request.headers.get("x-ninja-client-secret") || env.NINJAONE_CLIENT_SECRET;
+    // Shallow, unauthenticated liveness probe.
+    if (url.pathname === "/health" || url.pathname === "/healthz") {
+      return json({ status: "ok" });
+    }
 
-      if (!clientId || !clientSecret) {
-        return new Response(
-          JSON.stringify({
-            error: "Missing credentials",
-            message:
-              "Provide X-Ninja-Client-ID and X-Ninja-Client-Secret headers, or configure environment secrets",
-            required: ["X-Ninja-Client-ID", "X-Ninja-Client-Secret"],
-          }),
-          {
-            status: 401,
-            headers: { "Content-Type": "application/json" },
-          }
+    if (url.pathname === "/mcp") {
+      const isGatewayMode = (env.AUTH_MODE ?? "env") === "gateway";
+
+      let credOverrides: NinjaOneCredentials | undefined;
+      if (isGatewayMode) {
+        const { creds, error } = resolveGatewayCredentials(
+          (name) => request.headers.get(name) ?? undefined
         );
+        if (error) {
+          return json(
+            {
+              error: "Missing credentials",
+              message: error,
+              required: ["X-Ninja-Client-ID", "X-Ninja-Client-Secret"],
+              optional: ["X-Ninja-Region"],
+            },
+            401
+          );
+        }
+        credOverrides = creds;
+      } else {
+        // env mode: build credentials from Worker secrets if present.
+        // (Absent creds are fine — tools/list still works, tools/call errors.)
+        const { creds } = buildCredentials(
+          env.NINJAONE_CLIENT_ID,
+          env.NINJAONE_CLIENT_SECRET,
+          env.NINJAONE_REGION
+        );
+        credOverrides = creds;
       }
 
-      const server = createMcpServer();
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => crypto.randomUUID(),
+      // Fresh server + transport per request (stateless).
+      const server = await createMcpServer(credOverrides);
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
         enableJsonResponse: true,
       });
-
       await server.connect(transport);
 
-      // Convert the Web Request to a Node-compatible form handled by the transport
-      // Note: In production, you would use a CF Workers-compatible adapter
-      return new Response(
-        JSON.stringify({ status: "connected", transport: "streamable-http" }),
-        {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      try {
+        const response = await transport.handleRequest(request);
+        return withCors(response);
+      } finally {
+        await transport.close();
+        await server.close();
+      }
     }
 
-    // 404 for everything else
-    return new Response(
-      JSON.stringify({ error: "Not found", endpoints: ["/mcp", "/health"] }),
-      {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      }
+    return json(
+      { error: "Not found", endpoints: ["/mcp", "/health"] },
+      404
     );
   },
 };

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,6 +1,6 @@
 {
   "name": "ninjaone-mcp",
-  "main": "dist/worker.js",
+  "main": "src/worker.ts",
   "compatibility_date": "2026-02-01",
   "compatibility_flags": ["nodejs_compat"]
 }


### PR DESCRIPTION
## Summary

Fixes #33 **and** makes the one-click deploy buttons actually work end-to-end.

### Part 1 — GitHub Packages auth (the #33 401)
`@wyre-technology/node-ninjaone` is on the GitHub Packages npm registry, which has **no anonymous read even for public packages**. Cloud builders ran `npm install` with no token → 401.

- `.npmrc` reads the token from `NODE_AUTH_TOKEN` (the exact line `actions/setup-node` already generates fleet-wide → CI stays green; local devs run `export NODE_AUTH_TOKEN=$(gh auth token)`).
- `.do/app.yaml` declares a build-time `GITHUB_TOKEN` secret (Dockerfile `ARG GITHUB_TOKEN`).
- README documents the operator PAT (`read:packages`) build variable.
- Package now publishes to GitHub Packages (`npmPublish: true` + `publishConfig`).

### Part 2 — Real Cloudflare Workers MCP server
`src/worker.ts` was a stub returning a placeholder. It now serves the **full** MCP server via the SDK's `WebStandardStreamableHTTPServerTransport` (Request/Response), which runs natively on `workerd`.

- Extracted the server factory + credential helpers into a side-effect-free `src/mcp-server.ts`, shared by the stdio/Node-HTTP entrypoint (`index.ts`) and the Workers entrypoint (`worker.ts`) — **one** tool implementation, no duplication.
- `wrangler.json` `main` → `src/worker.ts` (bundled directly; no prebuilt `dist/`).
- Worker supports env-var creds **or** `AUTH_MODE=gateway` header creds, CORS preflight, `/health` probe, `/mcp` endpoint.
- `perf`: static tool list memoized across stateless requests (per `/simplify`).

## Verification
- `npm run build`, `npm run lint`, `npm test` → **114/114 pass** (incl. 7 new worker tests).
- **End-to-end on real `workerd` via `wrangler dev`:** `initialize` → correct serverInfo; `tools/list` → 24 tools; `tools/call ninjaone_status` → status; `tools/call ninjaone_devices_list` (no creds) → graceful isError.
- Reproduced the original 401 with token unset; confirmed install succeeds with `NODE_AUTH_TOKEN` set.

## Fleet
Part of a fleet-wide fix across the 16 repos carrying these buttons. The Workers pattern here (Web Standard transport + shared factory) is the template being rolled out to the others.