### PR TITLE
ci(dependabot): authenticate GitHub Packages registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
+registries:
+  wyre-ghpkg:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GHPKG_READ_TOKEN}}
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    registries:
+      - wyre-ghpkg
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Adds a Dependabot `registries:` block so it resolves the private `@wyre-technology/node-*` dep from GitHub Packages (was 401). Uses org Dependabot secret `GHPKG_READ_TOKEN`.