### PR TITLE
ci: centralize release pipeline via reusable mcp-server-release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,186 +6,37 @@ on:
   pull_request:
     branches: [main]
 
+# Thin caller for the canonical reusable release pipeline. The build →
+# semantic-release → Docker → MCP Registry → security chain (tag-based release
+# detection + correct gating) lives in wyre-technology/.github so every *-mcp
+# repo stays in lockstep instead of drifting per-repo. PR-time lint/test gating
+# is each repo's ci.yml concern; this workflow only runs the release path.
+# Caller jobs grant the token scopes the reusable jobs request (a reusable can
+# only reduce, never expand, caller-granted scope).
 jobs:
-  test:
-    name: Test
-    # Delegated to the canonical reusable CI workflow.
-    # See: ~/.claude/skills/mcp-server-fleet-ci-template
-    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
-    with:
-      node-versions: '["20", "22"]'
-    secrets: inherit
-
   release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
       issues: write
       packages: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      released: ${{ steps.version.outputs.released }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - name: Configure npm for GitHub Packages
-        run: |
-          echo "@wyre-technology:registry=https://npm.pkg.github.com" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
-      - run: npm ci
-      - run: npm run build
-      - name: Capture pre-release version
-        run: |
-          PRE_VERSION=$(node -p "require('./package.json').version")
-          echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Semantic Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
-
-      - name: Get released version
-        id: version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if [ "$VERSION" != "$PRE_VERSION" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Pack and upload MCPB bundle
-        if: steps.version.outputs.released == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BUNDLE_NAME=$(node -p "require('./package.json').name.replace(/^@.*\//, '')")
-          npm install -g @anthropic-ai/mcpb
-          npm run pack:mcpb
-          gh release upload "v${{ steps.version.outputs.version }}" "${BUNDLE_NAME}.mcpb" \
-            --repo ${{ github.repository }} --clobber
-
-      - name: Trigger MCP Gateway redeploy
-        if: steps.version.outputs.released == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GATEWAY_DEPLOY_PAT }}
-        run: |
-          gh api repos/wyre-technology/mcp-gateway/dispatches \
-            -f event_type=mcp-server-updated \
-            -f "client_payload[server]=${{ github.event.repository.name }}" \
-            -f "client_payload[version]=${{ steps.version.outputs.version }}"
-
-  docker:
-    name: Docker
-    runs-on: ubuntu-latest
-    needs: [test, release]
-    # Gate on an actual semantic-release. A non-release push to main would
-    # otherwise rebuild and re-push :latest tagged with the stale package.json
-    # version, clobbering the correctly-tagged :latest from the last real
-    # release. Skipping docker cascades to deploy/registry (skipped dependency).
-    if: needs.release.outputs.released == 'true'
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      # The push digest is the only race-proof way to deploy this exact build.
-      # `:latest` is mutable and can resolve to a stale layer; the digest is
-      # bulletproof and is what the reusable deploy workflow pins on.
-      digest: ${{ steps.push.outputs.digest }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-      - name: Resolve release version
-        id: version
-        env:
-          RELEASE_VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          if [ -z "$RELEASE_VERSION" ]; then
-            echo "ERROR: needs.release.outputs.version is empty" >&2
-            exit 1
-          fi
-          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v3
-      - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        id: push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:v${{ needs.release.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-  mcp-registry:
-    name: Publish to MCP Registry
-    runs-on: ubuntu-latest
-    needs: [release, docker]
-    if: needs.release.outputs.released == 'true'
-    permissions:
       id-token: write
-      contents: read
-    env:
-      VERSION: ${{ needs.release.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - name: Install mcp-publisher
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
-      - name: Stamp version into server.json
-        run: |
-          jq --arg v "$VERSION" \
-            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/ninjaone-mcp:v" + $v' \
-            server.json > server.json.tmp
-          mv server.json.tmp server.json
-          cat server.json
-      - name: Validate server.json
-        run: ./mcp-publisher validate
-      - name: Authenticate to MCP Registry (GitHub OIDC)
-        run: ./mcp-publisher login github-oidc
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
-      - name: Verify registry listing
-        run: |
-          sleep 5
-          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/ninjaone-mcp" \
-            | jq '.servers[]?.server | {name, version}'
+      security-events: write
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
+    with:
+      server-name: ninjaone-mcp
+      image-name: ghcr.io/wyre-technology/ninjaone-mcp
+    secrets: inherit
 
   deploy:
-    name: Deploy to Azure Container Apps
-    needs: [release, docker]
+    needs: release
     if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
-    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
     with:
       vendor-slug: ninjaone
       image-name: ghcr.io/wyre-technology/ninjaone-mcp
-      digest: ${{ needs.docker.outputs.digest }}
+      digest: ${{ needs.release.outputs.digest }}
       version: ${{ needs.release.outputs.version }}
     secrets: inherit


### PR DESCRIPTION
Replaces the inline release/docker/mcp-registry/deploy jobs with a thin caller of the reusable workflows in wyre-technology/.github (release via mcp-server-release.yml, deploy via mcp-server-deploy.yml). Fixes the 'duplicate version' MCP Registry failure from the old gh-release-view gating; release detection is now tag-based. Proven on domotz-mcp#27. Part of the fleet-wide centralization. vendor-slug=ninjaone.