### PR TITLE
fix!: require board_id for tickets_list instead of silent board-1 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `ninjaone_tickets_list` now requires `board_id` instead of
+  silently falling back to board 1 ([#54](https://github.com/wyre-technology/ninjaone-mcp/issues/54)).
+  Board IDs are tenant-specific — on multi-board tenants the old fallback could
+  return a near-empty queue (1 ticket instead of ~1,400 in the reported case)
+  with no indication anything was wrong. Omitting `board_id` now returns an
+  actionable error pointing at `ninjaone_tickets_boards_list`.
+- `ninjaone_tickets_boards_list` now returns actionable guidance when the
+  underlying endpoint (`GET /api/v2/ticketing/trigger/board`) responds 404,
+  which some tenants do — including how to find a board ID via the NinjaOne
+  web UI instead of a bare "Resource not found" error.
+
 ### Fixed
 
 - One-click deploys (Cloudflare Workers, DigitalOcean App Platform) no longer fail

--- a/README.md
+++ b/README.md
@@ -163,12 +163,20 @@ Tools:
 Manage service tickets.
 
 Tools:
-- `ninjaone_tickets_list` - List tickets with filters
+- `ninjaone_tickets_list` - List tickets from a board (requires `board_id`, see note below)
 - `ninjaone_tickets_get` - Get ticket details
 - `ninjaone_tickets_create` - Create a new ticket
 - `ninjaone_tickets_update` - Update an existing ticket
 - `ninjaone_tickets_add_comment` - Add a comment to a ticket
 - `ninjaone_tickets_comments` - Get ticket comments
+- `ninjaone_tickets_boards_list` - List ticket boards (to discover `board_id` values)
+
+> **Note:** NinjaOne queries tickets per board, and board IDs vary by tenant —
+> board 1 is *not* always the "All Tickets" board, so `ninjaone_tickets_list`
+> requires an explicit `board_id` rather than silently guessing one. Discover
+> IDs with `ninjaone_tickets_boards_list`; on tenants where that endpoint
+> returns 404, read the numeric ID from the board link's URL in the NinjaOne
+> web UI (e.g. the "All tickets" sidebar link).
 
 ## Navigation Tools
 

--- a/src/__tests__/domains/tickets.test.ts
+++ b/src/__tests__/domains/tickets.test.ts
@@ -127,6 +127,14 @@ describe("Tickets Domain Handler", () => {
       expect(toolNames).toContain("ninjaone_tickets_boards_list");
     });
 
+    it("ninjaone_tickets_list should require board_id", () => {
+      const tools = ticketsHandler.getTools();
+      const listTool = tools.find((t) => t.name === "ninjaone_tickets_list");
+
+      expect(listTool).toBeDefined();
+      expect(listTool?.inputSchema.required).toContain("board_id");
+    });
+
     it("ninjaone_tickets_get should require ticket_id", () => {
       const tools = ticketsHandler.getTools();
       const getTool = tools.find((t) => t.name === "ninjaone_tickets_get");
@@ -156,19 +164,34 @@ describe("Tickets Domain Handler", () => {
 
   describe("handleCall", () => {
     describe("ninjaone_tickets_list", () => {
-      it("should list tickets with default parameters", async () => {
-        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {});
+      it("should list tickets for an explicit board", async () => {
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 2,
+        });
 
         expect(result.isError).toBeUndefined();
         expect(result.content[0].type).toBe("text");
+        expect(mockTicketsList).toHaveBeenCalledWith(
+          expect.objectContaining({ boardId: 2 })
+        );
 
         const data = JSON.parse(result.content[0].text);
         expect(data.tickets).toHaveLength(2);
         expect(data.cursor).toBe("next-page");
       });
 
+      it("should return an actionable error when board_id is omitted", async () => {
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {});
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("board_id");
+        expect(result.content[0].text).toContain("ninjaone_tickets_boards_list");
+        expect(mockTicketsList).not.toHaveBeenCalled();
+      });
+
       it("should pass filters to API", async () => {
         await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 1,
           status: "OPEN",
           organization_id: 5,
           device_id: 10,
@@ -179,7 +202,7 @@ describe("Tickets Domain Handler", () => {
           status: "OPEN",
           organizationId: 5,
           deviceId: 10,
-          boardId: undefined,
+          boardId: 1,
           pageSize: 25,
           lastCursorId: undefined,
         });
@@ -315,6 +338,20 @@ describe("Tickets Domain Handler", () => {
         const data = JSON.parse(result.content[0].text);
         expect(data).toHaveLength(2);
         expect(data[0]).toEqual({ id: 1, name: "All Tickets" });
+      });
+
+      it("should return actionable guidance when the boards endpoint 404s", async () => {
+        const notFound = Object.assign(new Error("Resource not found"), {
+          name: "NinjaOneNotFoundError",
+          status: 404,
+        });
+        mockTicketsListBoards.mockRejectedValueOnce(notFound);
+
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_boards_list", {});
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("404");
+        expect(result.content[0].text).toContain("web UI");
       });
     });
 

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -18,10 +18,20 @@ function getTools(): Tool[] {
     {
       name: "ninjaone_tickets_list",
       description:
-        "List tickets, filterable by status, organization, or device",
+        "List tickets from a ticket board, filterable by status, organization, or device. " +
+        "Requires board_id: NinjaOne queries tickets per board and board IDs vary by tenant " +
+        "(board 1 is NOT always the 'All Tickets' board). Discover board IDs with " +
+        "ninjaone_tickets_boards_list first.",
       inputSchema: {
         type: "object" as const,
         properties: {
+          board_id: {
+            type: "number",
+            description:
+              "Ticket board to query. Use ninjaone_tickets_boards_list to discover valid IDs; " +
+              "if that endpoint is unavailable on your tenant, read the ID from the board's URL " +
+              "in the NinjaOne web UI.",
+          },
           status: {
             type: "string",
             enum: ["OPEN", "IN_PROGRESS", "WAITING", "CLOSED"],
@@ -32,9 +42,6 @@ function getTools(): Tool[] {
           device_id: {
             type: "number",
           },
-          board_id: {
-            type: "number",
-          },
           limit: {
             type: "number",
           },
@@ -42,6 +49,7 @@ function getTools(): Tool[] {
             type: "string",
           },
         },
+        required: ["board_id"],
       },
     },
     {
@@ -176,6 +184,28 @@ async function handleCall(
 
   switch (toolName) {
     case "ninjaone_tickets_list": {
+      // Board IDs are tenant-specific; guessing one (the SDK used to default to
+      // board 1) silently returns the wrong board's tickets on multi-board
+      // tenants, so refuse to run without an explicit board_id.
+      const boardId = args.board_id;
+      if (typeof boardId !== "number" || !Number.isFinite(boardId)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                "board_id is required: NinjaOne queries tickets per board, and board IDs " +
+                "vary by tenant — board 1 is not guaranteed to be the 'All Tickets' board, " +
+                "so guessing a default can silently return the wrong board's tickets. " +
+                "Call ninjaone_tickets_boards_list to discover board IDs; if that endpoint " +
+                "returns 404 on your tenant, read the ID from the board's URL in the " +
+                "NinjaOne web UI (e.g. the 'All tickets' sidebar link).",
+            },
+          ],
+          isError: true,
+        };
+      }
+
       const limit = (args.limit as number) || 50;
       const cursor = args.cursor as string | undefined;
       logger.info("API call: tickets.list", {
@@ -191,7 +221,7 @@ async function handleCall(
         status: args.status as TicketStatus | undefined,
         organizationId: args.organization_id as number | undefined,
         deviceId: args.device_id as number | undefined,
-        boardId: args.board_id as number | undefined,
+        boardId,
         pageSize: limit,
         lastCursorId: cursor !== undefined ? Number(cursor) : undefined,
       });
@@ -279,7 +309,31 @@ async function handleCall(
 
     case "ninjaone_tickets_boards_list": {
       logger.info("API call: tickets.listBoards");
-      const boards = await client.tickets.listBoards();
+      let boards: unknown[];
+      try {
+        boards = await client.tickets.listBoards();
+      } catch (error) {
+        // Some tenants 404 on GET /api/v2/ticketing/trigger/board, leaving no
+        // API path to discover board IDs — point the caller at the web UI
+        // instead of surfacing a bare "Resource not found".
+        const status = (error as { status?: number }).status;
+        if (status === 404) {
+          return {
+            content: [
+              {
+                type: "text",
+                text:
+                  "The board listing endpoint (GET /api/v2/ticketing/trigger/board) returned " +
+                  "404 — some NinjaOne tenants do not expose it. To find a board_id for " +
+                  "ninjaone_tickets_list, open Ticketing in the NinjaOne web UI and read the " +
+                  "numeric ID from the board link's URL (e.g. the 'All tickets' sidebar link).",
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw error;
+      }
       logger.debug("API response: tickets.listBoards", { count: boards.length });
 
       return {


### PR DESCRIPTION
## Summary

Fixes #54. `ninjaone_tickets_list` let `board_id` default (via the SDK's `boardId ?? 1` fallback) to board 1, which is **not** the "All Tickets" board on every tenant. On the reporter's multi-board tenant this silently returned 1 ticket instead of ~1,400 — no error, no warning, badly wrong data for anyone using the tool for reporting or syncing.

## Changes

- **`ninjaone_tickets_list` now requires `board_id`** (tool schema `required` + runtime guard). Omitting it returns an actionable `isError` result explaining why there is no safe default and pointing at `ninjaone_tickets_boards_list`.
- **`ninjaone_tickets_boards_list` handles the tenant-404 case**: some tenants 404 on `GET /api/v2/ticketing/trigger/board`, leaving no API path to discover board IDs. Instead of a bare `Error: Resource not found`, the tool now explains the situation and how to read the board ID from the board link's URL in the NinjaOne web UI (how the reporter found theirs).
- Tool/param descriptions and README updated so callers learn the board model before hitting the failure.
- CHANGELOG updated (Unreleased → Changed).

## Root cause / companion PR

The silent fallback itself lives in the SDK — wyre-technology/node-ninjaone#49 removes it there (`boardId` becomes required in `TicketListParams`). This PR is self-sufficient: the runtime guard fires before the SDK call, so it works with the current SDK version and stays correct after the SDK major bump.

## Breaking change

Calls to `ninjaone_tickets_list` without `board_id` now return an error instead of board 1's tickets. That is the point of #54 — the old behavior was a silent, severe under-count.

## Not addressed here

The issue also mentions `ninjaone_devices_list` silently truncating to ~50 results with no cursor — same pattern, separate tool; filing as a follow-up issue so it isn't lost.

## Testing

- New tests (all verified failing before the fix): schema requires `board_id`; omission returns an actionable error without calling the API; boards-list 404 returns guidance mentioning the web UI.
- 117/117 tests pass, `tsc` build clean, eslint clean.