### PR TITLE
fix(deps): bump @wyre-technology/node-ninjaone to ^2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a61021de876d0fd44dac777fa90f963fea25b0c3
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@a925b43adb22aa8885b8243e1056e6a42cdce4d1
     with:
       server-name: ninjaone-mcp
       image-name: ghcr.io/wyre-technology/ninjaone-mcp

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@wyre-technology/node-ninjaone": "^1.1.2"
+        "@wyre-technology/node-ninjaone": "^2.0.0"
       },
       "bin": {
         "ninjaone-mcp": "dist/index.js"
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/@wyre-technology/node-ninjaone": {
-      "version": "1.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/1.1.2/2d88096e8b223f2ce6ee67749cd70f9c39072fea",
-      "integrity": "sha512-VdhwQMs4Scd/OH79O5zfg/1CGjqdLR4FN+qtb0cgGWCtJfYIYtSUsEfhywDMQwVljVoReHV+/4VQVDVUUz93hg==",
+      "version": "2.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/2.0.0/cb9b94edcac40d678ad19de9bb777eedd8e9ed6b",
+      "integrity": "sha512-mLU5FVVRoLfv8pwlh4tT8CEltQr3KkkdbSnhbbsg7S2d4bSSg8+oOwzw1Lv1IvdDo2unc6ltGGcRdSgXldPfXQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/wyre-technology/ninjaone-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
-    "@wyre-technology/node-ninjaone": "^1.1.2"
+    "@wyre-technology/node-ninjaone": "^2.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Follow-up to #55 / node-ninjaone#49 (the #54 fix chain). Two commits:

1. **Bump `@wyre-technology/node-ninjaone` to ^2.0.0** — picks up the SDK major that removed the silent `boardId ?? 1` fallback at the source, so the published server no longer even contains the fallback code path. No source changes: `ninjaone_tickets_list` already requires and always passes `board_id`, which satisfies the SDK's now-required `boardId` parameter — verified by a clean `tsc` build against 2.0.0 and 117/117 tests passing.

2. **Re-pin the release reusable to wyre-technology/.github#32** — the v2.0.0 release cut fine but its Docker image build 403'd on the SDK install: the npm registry rejects custom App installation tokens for cross-repo package reads (`Permission installation not allowed to Read organization package`). The fixed reusable authenticates npm with `GITHUB_TOKEN` + `packages: read`, the same proven pattern mcp-assert uses. Merging this PR cuts v2.0.1 and ships the image + MCP Registry publish + deploy that v2.0.0 skipped.