### PR TITLE
fix(devices): forward class/online filters and surface pagination cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 
 ### Fixed
 
+- `ninjaone_devices_list` now forwards the `device_class` and `online` filters to
+  the API — they were logged but never sent, so filtered calls silently returned
+  the full unfiltered fleet ([#56](https://github.com/wyre-technology/ninjaone-mcp/issues/56)).
+  The `device_class` enum is corrected to real NinjaOne node classes (`LINUX` and
+  `VMWARE_VM` were never valid). The response now includes `count`, an explicit
+  `hasMore` flag, and a `cursor` (the last device id) so the ~50-result page limit
+  is detectable and paginable instead of a silent truncation.
 - One-click deploys (Cloudflare Workers, DigitalOcean App Platform) no longer fail
   with `npm error 401 Unauthorized ... npm.pkg.github.com` ([#33](https://github.com/wyre-technology/ninjaone-mcp/issues/33)).
   `.npmrc` now carries an `_authToken=${NODE_AUTH_TOKEN}` line so the cloud builder

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ docker run -e NINJAONE_CLIENT_ID=xxx -e NINJAONE_CLIENT_SECRET=xxx -e NINJAONE_R
 Manage endpoints, reboot devices, view services and alerts.
 
 Tools:
-- `ninjaone_devices_list` - List devices with filters
+- `ninjaone_devices_list` - List devices, filterable by organization, device class, and online status. Paginated: a full page returns `hasMore: true` and a `cursor` to pass back for the next page.
 - `ninjaone_devices_get` - Get device details
 - `ninjaone_devices_reboot` - Schedule a device reboot
 - `ninjaone_devices_services` - List Windows services on a device

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",
-        "@wyre-technology/node-ninjaone": "^2.0.0"
+        "@wyre-technology/node-ninjaone": "^2.0.1"
       },
       "bin": {
         "ninjaone-mcp": "dist/index.js"
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/@wyre-technology/node-ninjaone": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/2.0.0/cb9b94edcac40d678ad19de9bb777eedd8e9ed6b",
-      "integrity": "sha512-mLU5FVVRoLfv8pwlh4tT8CEltQr3KkkdbSnhbbsg7S2d4bSSg8+oOwzw1Lv1IvdDo2unc6ltGGcRdSgXldPfXQ==",
+      "version": "2.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/2.0.1/eee791617aba3ca1920dfa54a46288fb20e92f01",
+      "integrity": "sha512-DUvO4v9dGLNIDF5shblNuPpRDV5Emxx3htkIG4MOAG5kwjRdEXsUJNQFphpdDR+Xj9FWqC8MSoKk3iZeR2022A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/wyre-technology/ninjaone-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.3",
-    "@wyre-technology/node-ninjaone": "^2.0.0"
+    "@wyre-technology/node-ninjaone": "^2.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/__tests__/domains/devices.test.ts
+++ b/src/__tests__/domains/devices.test.ts
@@ -142,7 +142,7 @@ describe("Devices Domain Handler", () => {
         expect(data.devices).toHaveLength(2);
       });
 
-      it("should pass filters to API", async () => {
+      it("should forward class and online filters to the API", async () => {
         await devicesHandler.handleCall("ninjaone_devices_list", {
           organization_id: 5,
           device_class: "WINDOWS_SERVER",
@@ -152,9 +152,61 @@ describe("Devices Domain Handler", () => {
 
         expect(mockDevicesList).toHaveBeenCalledWith({
           organizationId: 5,
+          nodeClass: "WINDOWS_SERVER",
+          status: "ONLINE",
           pageSize: 10,
           cursor: undefined,
         });
+      });
+
+      it("should map online:false to OFFLINE status", async () => {
+        await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          online: false,
+        });
+
+        expect(mockDevicesList).toHaveBeenCalledWith(
+          expect.objectContaining({ status: "OFFLINE" })
+        );
+      });
+
+      it("should omit the status filter when online is not provided", async () => {
+        await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+        });
+
+        const passed = mockDevicesList.mock.calls[0][0];
+        expect(passed.status).toBeUndefined();
+      });
+
+      it("should surface a pagination cursor when a full page is returned", async () => {
+        // A page exactly the size of the limit signals possible truncation.
+        mockDevicesList.mockResolvedValueOnce([
+          { id: 11, systemName: "A", organizationId: 1 },
+          { id: 22, systemName: "B", organizationId: 1 },
+        ]);
+
+        const result = await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          limit: 2,
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.count).toBe(2);
+        expect(data.hasMore).toBe(true);
+        expect(data.cursor).toBe("22");
+      });
+
+      it("should not surface a cursor when the page is not full", async () => {
+        // Default mock returns 2 devices; limit 50 → not a full page.
+        const result = await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          limit: 50,
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.hasMore).toBe(false);
+        expect(data.cursor).toBeUndefined();
       });
     });
 

--- a/src/domains/devices.ts
+++ b/src/domains/devices.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { DeviceNodeClass } from "@wyre-technology/node-ninjaone";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";
@@ -27,16 +28,27 @@ function getTools(): Tool[] {
           },
           device_class: {
             type: "string",
-            enum: ["WINDOWS_WORKSTATION", "WINDOWS_SERVER", "MAC", "LINUX", "VMWARE_VM"],
+            enum: [
+              "WINDOWS_WORKSTATION",
+              "WINDOWS_SERVER",
+              "MAC",
+              "LINUX_WORKSTATION",
+              "LINUX_SERVER",
+              "VMWARE_VM_HOST",
+              "VMWARE_VM_GUEST",
+              "NMS",
+            ],
           },
           online: {
             type: "boolean",
           },
           limit: {
             type: "number",
+            description: "Max devices to return (default 50). A full page sets hasMore=true and returns a cursor.",
           },
           cursor: {
             type: "string",
+            description: "Pagination cursor from a previous response's cursor field (the last device id).",
           },
         },
       },
@@ -170,6 +182,14 @@ async function handleCall(
         }
       }
 
+      // Map the tool's online boolean onto the SDK's status filter.
+      const status =
+        args.online === undefined
+          ? undefined
+          : args.online
+            ? "ONLINE"
+            : "OFFLINE";
+
       logger.info("API call: devices.list", {
         organizationId,
         deviceClass: args.device_class,
@@ -180,16 +200,33 @@ async function handleCall(
 
       const devices = await client.devices.list({
         organizationId,
+        nodeClass: args.device_class as DeviceNodeClass | undefined,
+        status,
         pageSize: limit,
         cursor,
       });
       logger.debug("API response: devices.list", { deviceCount: devices.length });
 
+      // GET /v2/devices has no total count and paginates by device id (the API's
+      // `after` param returns ids greater than the cursor), so a page exactly the
+      // size of the limit means results were likely truncated. Surface an explicit
+      // hasMore flag and a cursor — the max id in this page, which the caller passes
+      // back as `cursor` to fetch the next page. Without this, truncation is silent
+      // and indistinguishable from "that's all of them".
+      const hasMore = devices.length === limit;
+      const nextCursor = hasMore
+        ? String(Math.max(...devices.map((d) => d.id)))
+        : undefined;
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ devices }, null, 2),
+            text: JSON.stringify(
+              { devices, count: devices.length, hasMore, cursor: nextCursor },
+              null,
+              2
+            ),
           },
         ],
       };


### PR DESCRIPTION
## Summary

Fixes #56 — the "silent incomplete data" pattern in `ninjaone_devices_list`, the follow-up filed alongside #54.

Two independent bugs, plus a latent third found while fixing them:

1. **Filters were logged but never sent.** The handler logged `device_class` and `online` but only passed `organizationId`/`pageSize`/`cursor` to the SDK, so any filtered call silently returned the **full unfiltered fleet**. Now forwarded as `nodeClass` and `status` (`online: true → ONLINE`, `false → OFFLINE`).
2. **Silent ~50-result truncation.** The response was `{ devices }` with no total, cursor, or more-results signal, so a caller couldn't tell 50 from 5,000. Now returns `{ devices, count, hasMore, cursor }` — `hasMore` is true when a full page comes back, and `cursor` (the max device id in the page) is what you pass back as `cursor` to fetch the next page. `GET /v2/devices` paginates by id via `after`, so an id-based cursor is the correct mechanism.
3. **Invalid enum values (found while fixing #1).** The `device_class` enum listed `LINUX` and `VMWARE_VM`, which are not real NinjaOne node classes — even once forwarded they'd produce filters the API rejects. Corrected to the SDK's `DeviceNodeClass` set (`LINUX_WORKSTATION`, `LINUX_SERVER`, `VMWARE_VM_HOST`, `VMWARE_VM_GUEST`, `NMS`, …).

## Dependency

Filter **forwarding** takes full effect once the SDK compiles `nodeClass`/`status` into a `df` expression — wyre-technology/node-ninjaone#50 (the API ignores named filter params; only `df` works). This PR is safe against the current SDK 2.0.0 (no regression — the params are simply passed through), and I'll bump the SDK version here once #50 releases. The **pagination** half is effective immediately.

## Testing

- Rewrote the stale "should pass filters to API" test (which asserted the broken drop-the-filters behavior) to assert `nodeClass`/`status` forwarding; added tests for `online:false → OFFLINE`, status omitted when absent, cursor present on a full page, and cursor absent on a partial page. All verified failing before the change.
- 121/121 tests pass, `tsc` clean, eslint clean.
- E2E-verified over the stdio MCP protocol that `tools/list` advertises the corrected `device_class` enum.

Fixes #56