### PR TITLE
fix(tickets,devices): make status/organization filters work instead of silently failing (#60, #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@
 
 ### Fixed
 
+- `ninjaone_tickets_list` no longer throws a generic `Bad request` when a
+  `status`, `organization_id`, or `device_id` filter is supplied
+  ([#61](https://github.com/wyre-technology/ninjaone-mcp/issues/61),
+  [#60](https://github.com/wyre-technology/ninjaone-mcp/issues/60)). NinjaOne's
+  board-run endpoint cannot filter tickets by those fields server-side (the SDK
+  sent a filter body the API rejects, and the 400 was indistinguishable from an
+  auth failure — a silent-failure that reported *zero* open tickets across live
+  client accounts). The handler now fetches the board page **without** those
+  filters and matches them client-side (status against each ticket's status
+  display name, organization against `clientId`, device against `nodeId`). The
+  response separates `count` (matches in this page) from `scanned` and includes
+  `hasMore`/`cursor`, so a single page's matches can never be mistaken for a
+  board-wide total.
+- `ninjaone_devices_list` now filters by `organization_id` reliably
+  ([#60](https://github.com/wyre-technology/ninjaone-mcp/issues/60)). The general
+  `GET /v2/devices` device filter (`df=org=<id>`) is silently dropped by NinjaOne
+  often enough to be unusable — a dropped filter returned the entire fleet — so an
+  organization-scoped query now routes through the dedicated
+  `GET /v2/organization/{id}/devices` endpoint, which scopes by org through the
+  URL path and can't be ignored. `device_class`/`online` are applied client-side
+  on that path (it has no `df` support), and pagination (`hasMore`/`cursor`) is
+  preserved.
 - `ninjaone_devices_list` now forwards the `device_class` and `online` filters to
   the API — they were logged but never sent, so filtered calls silently returned
   the full unfiltered fleet ([#56](https://github.com/wyre-technology/ninjaone-mcp/issues/56)).

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Tools:
 Manage service tickets.
 
 Tools:
-- `ninjaone_tickets_list` - List tickets from a board (requires `board_id`, see note below)
+- `ninjaone_tickets_list` - List tickets from a board (requires `board_id`; `status`/`organization_id`/`device_id` filters are applied client-side, see notes below)
 - `ninjaone_tickets_get` - Get ticket details
 - `ninjaone_tickets_create` - Create a new ticket
 - `ninjaone_tickets_update` - Update an existing ticket
@@ -177,6 +177,20 @@ Tools:
 > IDs with `ninjaone_tickets_boards_list`; on tenants where that endpoint
 > returns 404, read the numeric ID from the board link's URL in the NinjaOne
 > web UI (e.g. the "All tickets" sidebar link).
+>
+> **Note:** NinjaOne's board-run API cannot filter tickets by status,
+> organization, or device server-side (attempting to throws a generic
+> `Bad request`). `ninjaone_tickets_list` therefore applies those filters
+> **client-side within one board page**. The response separates `count` (matches
+> in this page) from `scanned` (tickets examined) and includes `hasMore`/`cursor`
+> — page through until `hasMore` is `false` to get every match, and never treat a
+> single page's `count` as a board-wide total. Status is matched against each
+> ticket's status display name, so custom board statuses may not map to the
+> `OPEN`/`IN_PROGRESS`/`WAITING`/`CLOSED` values.
+>
+> Similarly, `ninjaone_devices_list` filters by `organization_id` through
+> NinjaOne's dedicated per-organization endpoint (the general `df=org` device
+> filter is unreliable and can silently return the full fleet).
 
 ## Navigation Tools
 

--- a/src/__tests__/domains/devices.test.ts
+++ b/src/__tests__/domains/devices.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Create mock functions using vi.hoisted so they're available when vi.mock is hoisted
 const {
   mockDevicesList,
+  mockDevicesListByOrganization,
   mockDevicesGet,
   mockDevicesReboot,
   mockDevicesGetServices,
@@ -15,6 +16,7 @@ const {
   mockClient,
 } = vi.hoisted(() => {
   const mockDevicesList = vi.fn();
+  const mockDevicesListByOrganization = vi.fn();
   const mockDevicesGet = vi.fn();
   const mockDevicesReboot = vi.fn();
   const mockDevicesGetServices = vi.fn();
@@ -24,6 +26,7 @@ const {
   const mockClient = {
     devices: {
       list: mockDevicesList,
+      listByOrganization: mockDevicesListByOrganization,
       get: mockDevicesGet,
       reboot: mockDevicesReboot,
       getServices: mockDevicesGetServices,
@@ -36,6 +39,7 @@ const {
 
   return {
     mockDevicesList,
+    mockDevicesListByOrganization,
     mockDevicesGet,
     mockDevicesReboot,
     mockDevicesGetServices,
@@ -64,6 +68,7 @@ describe("Devices Domain Handler", () => {
   beforeEach(() => {
     // Clear call history
     mockDevicesList.mockClear();
+    mockDevicesListByOrganization.mockClear();
     mockDevicesGet.mockClear();
     mockDevicesReboot.mockClear();
     mockDevicesGetServices.mockClear();
@@ -74,6 +79,12 @@ describe("Devices Domain Handler", () => {
     mockDevicesList.mockResolvedValue([
       { id: 1, systemName: "Device 1", organizationId: 1 },
       { id: 2, systemName: "Device 2", organizationId: 1 },
+    ]);
+    // Organization-scoped endpoint returns that org's devices (raw NinjaOne
+    // shape: nodeClass + offline boolean, no ONLINE/OFFLINE status string).
+    mockDevicesListByOrganization.mockResolvedValue([
+      { id: 3, systemName: "Srv", organizationId: 5, nodeClass: "WINDOWS_SERVER", offline: false },
+      { id: 4, systemName: "Wks", organizationId: 5, nodeClass: "WINDOWS_WORKSTATION", offline: true },
     ]);
     mockDevicesGet.mockResolvedValue({
       id: 1,
@@ -142,26 +153,27 @@ describe("Devices Domain Handler", () => {
         expect(data.devices).toHaveLength(2);
       });
 
-      it("should forward class and online filters to the API", async () => {
+      it("should forward class and online filters to /v2/devices (df path, no org)", async () => {
         await devicesHandler.handleCall("ninjaone_devices_list", {
-          organization_id: 5,
           device_class: "WINDOWS_SERVER",
           online: true,
           limit: 10,
         });
 
+        // With no organization filter, class/online go server-side via the `df`
+        // query on GET /v2/devices. organizationId must NOT be passed here — the
+        // API silently drops `df=org`, which is the whole point of #60.
         expect(mockDevicesList).toHaveBeenCalledWith({
-          organizationId: 5,
           nodeClass: "WINDOWS_SERVER",
           status: "ONLINE",
           pageSize: 10,
           cursor: undefined,
         });
+        expect(mockDevicesListByOrganization).not.toHaveBeenCalled();
       });
 
       it("should map online:false to OFFLINE status", async () => {
         await devicesHandler.handleCall("ninjaone_devices_list", {
-          organization_id: 5,
           online: false,
         });
 
@@ -172,11 +184,57 @@ describe("Devices Domain Handler", () => {
 
       it("should omit the status filter when online is not provided", async () => {
         await devicesHandler.handleCall("ninjaone_devices_list", {
-          organization_id: 5,
+          device_class: "MAC",
         });
 
         const passed = mockDevicesList.mock.calls[0][0];
         expect(passed.status).toBeUndefined();
+      });
+
+      it("should route organization_id to the org-scoped endpoint (#60)", async () => {
+        // NinjaOne silently drops `df=org` on GET /v2/devices, leaking the whole
+        // fleet. The org must be scoped via the path-based endpoint instead.
+        const result = await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          limit: 10,
+        });
+
+        expect(mockDevicesListByOrganization).toHaveBeenCalledWith(5, {
+          pageSize: 10,
+          after: undefined,
+        });
+        expect(mockDevicesList).not.toHaveBeenCalled();
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.count).toBe(2);
+        expect(data.devices.every((d: { organizationId: number }) => d.organizationId === 5)).toBe(true);
+      });
+
+      it("should filter class/online client-side on the org endpoint", async () => {
+        // The org endpoint has no `df`, so class/online can't be applied by the
+        // API — they must be filtered in code rather than silently ignored.
+        const result = await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          device_class: "WINDOWS_SERVER",
+          online: true,
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.count).toBe(1);
+        expect(data.devices[0].nodeClass).toBe("WINDOWS_SERVER");
+        expect(data.devices[0].offline).toBe(false);
+      });
+
+      it("should paginate the org endpoint via the after cursor", async () => {
+        await devicesHandler.handleCall("ninjaone_devices_list", {
+          organization_id: 5,
+          cursor: "99",
+        });
+
+        expect(mockDevicesListByOrganization).toHaveBeenCalledWith(
+          5,
+          expect.objectContaining({ after: 99 })
+        );
       });
 
       it("should surface a pagination cursor when a full page is returned", async () => {
@@ -187,7 +245,7 @@ describe("Devices Domain Handler", () => {
         ]);
 
         const result = await devicesHandler.handleCall("ninjaone_devices_list", {
-          organization_id: 5,
+          device_class: "WINDOWS_SERVER",
           limit: 2,
         });
 
@@ -200,7 +258,7 @@ describe("Devices Domain Handler", () => {
       it("should not surface a cursor when the page is not full", async () => {
         // Default mock returns 2 devices; limit 50 → not a full page.
         const result = await devicesHandler.handleCall("ninjaone_devices_list", {
-          organization_id: 5,
+          device_class: "WINDOWS_SERVER",
           limit: 50,
         });
 

--- a/src/__tests__/domains/tickets.test.ts
+++ b/src/__tests__/domains/tickets.test.ts
@@ -189,7 +189,9 @@ describe("Tickets Domain Handler", () => {
         expect(mockTicketsList).not.toHaveBeenCalled();
       });
 
-      it("should pass filters to API", async () => {
+      it("should NOT send status/org/device filters to the board API (#60, #61)", async () => {
+        // NinjaOne's board-run endpoint 400s on these filters, so the handler must
+        // never forward them — it fetches the board page and filters client-side.
         await ticketsHandler.handleCall("ninjaone_tickets_list", {
           board_id: 1,
           status: "OPEN",
@@ -199,13 +201,93 @@ describe("Tickets Domain Handler", () => {
         });
 
         expect(mockTicketsList).toHaveBeenCalledWith({
-          status: "OPEN",
-          organizationId: 5,
-          deviceId: 10,
           boardId: 1,
           pageSize: 25,
           lastCursorId: undefined,
         });
+        const passed = mockTicketsList.mock.calls[0][0];
+        expect(passed).not.toHaveProperty("status");
+        expect(passed).not.toHaveProperty("organizationId");
+        expect(passed).not.toHaveProperty("deviceId");
+      });
+
+      it("should filter tickets by status client-side (board-row status object)", async () => {
+        mockTicketsList.mockResolvedValueOnce({
+          data: [
+            { id: 1, status: { statusId: 2000, displayName: "Open" }, clientId: 5, nodeId: 10 },
+            { id: 2, status: { statusId: 4000, displayName: "In Progress" }, clientId: 5, nodeId: 11 },
+            { id: 3, status: { statusId: 2000, displayName: "Open" }, clientId: 7, nodeId: 12 },
+          ],
+        });
+
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 1,
+          status: "OPEN",
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.count).toBe(2);
+        expect(data.scanned).toBe(3);
+        expect(data.tickets.map((t: { id: number }) => t.id)).toEqual([1, 3]);
+        expect(data.note).toContain("client-side");
+      });
+
+      it("should match status enum against the display name (IN_PROGRESS → 'In Progress')", async () => {
+        mockTicketsList.mockResolvedValueOnce({
+          data: [
+            { id: 1, status: { statusId: 2000, displayName: "Open" } },
+            { id: 2, status: { statusId: 4000, displayName: "In Progress" } },
+          ],
+        });
+
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 1,
+          status: "IN_PROGRESS",
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.tickets.map((t: { id: number }) => t.id)).toEqual([2]);
+      });
+
+      it("should filter by organization (clientId) and device (nodeId) client-side", async () => {
+        mockTicketsList.mockResolvedValueOnce({
+          data: [
+            { id: 1, status: { displayName: "Open" }, clientId: 5, nodeId: 10 },
+            { id: 2, status: { displayName: "Open" }, clientId: 5, nodeId: 99 },
+            { id: 3, status: { displayName: "Open" }, clientId: 7, nodeId: 10 },
+          ],
+        });
+
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 1,
+          organization_id: 5,
+          device_id: 10,
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.tickets.map((t: { id: number }) => t.id)).toEqual([1]);
+      });
+
+      it("should flag hasMore and a cursor when the board page is full", async () => {
+        // A full page (length === limit) means the board has more tickets.
+        mockTicketsList.mockResolvedValueOnce({
+          data: [
+            { id: 10, status: { displayName: "Open" }, clientId: 5 },
+            { id: 20, status: { displayName: "Closed" }, clientId: 5 },
+          ],
+        });
+
+        const result = await ticketsHandler.handleCall("ninjaone_tickets_list", {
+          board_id: 1,
+          status: "OPEN",
+          limit: 2,
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.count).toBe(1); // only the Open one matched...
+        expect(data.scanned).toBe(2); // ...out of 2 scanned
+        expect(data.hasMore).toBe(true); // full page → more tickets exist
+        expect(data.cursor).toBe("20"); // resume after the max row id
       });
 
       it("should forward cursor as lastCursorId for pagination", async () => {

--- a/src/domains/devices.ts
+++ b/src/domains/devices.ts
@@ -12,6 +12,40 @@ import { logger } from "../utils/logger.js";
 import { elicitSelection } from "../utils/elicitation.js";
 
 /**
+ * Client-side device filter for the organization-scoped endpoint
+ * (GET /v2/organization/{id}/devices), which — unlike GET /v2/devices — accepts
+ * no `df` query, so class/online can't be filtered by the API there.
+ *
+ * Online-ness is read from the raw NinjaOne device (`offline` boolean), falling
+ * back to the SDK's `status` field. When it can't be determined, the device is
+ * treated as a match so an unexpected field shape degrades to "unfiltered"
+ * rather than silently dropping every device.
+ */
+function deviceMatchesFilters(
+  device: { nodeClass?: string; status?: string; offline?: boolean },
+  deviceClass: string | undefined,
+  online: boolean | undefined
+): boolean {
+  if (deviceClass !== undefined && device.nodeClass !== deviceClass) {
+    return false;
+  }
+  if (online !== undefined) {
+    const isOnline =
+      typeof device.offline === "boolean"
+        ? !device.offline
+        : device.status === "ONLINE"
+          ? true
+          : device.status === "OFFLINE"
+            ? false
+            : undefined;
+    if (isOnline !== undefined && isOnline !== online) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Get device domain tools
  */
 function getTools(): Tool[] {
@@ -190,6 +224,8 @@ async function handleCall(
             ? "ONLINE"
             : "OFFLINE";
 
+      const deviceClass = args.device_class as DeviceNodeClass | undefined;
+
       logger.info("API call: devices.list", {
         organizationId,
         deviceClass: args.device_class,
@@ -198,25 +234,54 @@ async function handleCall(
         cursor,
       });
 
-      const devices = await client.devices.list({
-        organizationId,
-        nodeClass: args.device_class as DeviceNodeClass | undefined,
-        status,
-        pageSize: limit,
-        cursor,
-      });
-      logger.debug("API response: devices.list", { deviceCount: devices.length });
+      // NinjaOne's GET /v2/devices compiles organizationId into a `df=org=<id>`
+      // device filter, but the API silently drops that filter often enough that it
+      // can't be relied on (issue #60) — when dropped it returns the entire fleet
+      // instead of erroring. The dedicated GET /v2/organization/{id}/devices
+      // endpoint scopes by org through the URL path, which the API can't ignore, so
+      // route through it whenever an organization is specified. That endpoint takes
+      // only pageSize + after (no `df`), so class/online are filtered client-side.
+      const after =
+        cursor !== undefined && Number.isFinite(Number(cursor))
+          ? Number(cursor)
+          : undefined;
+
+      const rawDevices =
+        organizationId !== undefined
+          ? await client.devices.listByOrganization(organizationId, {
+              pageSize: limit,
+              after,
+            })
+          : await client.devices.list({
+              nodeClass: deviceClass,
+              status,
+              pageSize: limit,
+              cursor,
+            });
+      logger.debug("API response: devices.list", { deviceCount: rawDevices.length });
 
       // GET /v2/devices has no total count and paginates by device id (the API's
       // `after` param returns ids greater than the cursor), so a page exactly the
       // size of the limit means results were likely truncated. Surface an explicit
       // hasMore flag and a cursor — the max id in this page, which the caller passes
-      // back as `cursor` to fetch the next page. Without this, truncation is silent
-      // and indistinguishable from "that's all of them".
-      const hasMore = devices.length === limit;
+      // back as `cursor` to fetch the next page. Compute this from the raw page
+      // (before any client-side filtering) so `hasMore` tracks the API's paging and
+      // not the filtered subset — otherwise a page that filters down to a handful of
+      // devices would look like the last page when it isn't.
+      const hasMore = rawDevices.length === limit;
       const nextCursor = hasMore
-        ? String(Math.max(...devices.map((d) => d.id)))
+        ? String(Math.max(...rawDevices.map((d) => d.id)))
         : undefined;
+
+      // The organization endpoint can't apply class/online server-side, so filter
+      // them here rather than silently ignore them. (On the no-org path the `df`
+      // query already applied them.)
+      const devices =
+        organizationId !== undefined
+          ? rawDevices.filter((d) =>
+              deviceMatchesFilters(d, deviceClass, args.online as boolean | undefined)
+            )
+          : rawDevices;
 
       return {
         content: [

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -11,6 +11,68 @@ import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";
 
 /**
+ * Extract the ticket rows from an SDK board-run response, which may arrive as a
+ * bare array, `{ tickets: [...] }`, or the raw `{ data: [...], metadata }` board
+ * envelope depending on what NinjaOne returns for the tenant.
+ */
+function extractTickets(response: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(response)) return response as Array<Record<string, unknown>>;
+  const r = (response ?? {}) as { tickets?: unknown; data?: unknown };
+  if (Array.isArray(r.tickets)) return r.tickets as Array<Record<string, unknown>>;
+  if (Array.isArray(r.data)) return r.data as Array<Record<string, unknown>>;
+  return [];
+}
+
+/** Collapse status labels for comparison: "IN_PROGRESS" and "In Progress" → "inprogress". */
+function normalizeStatus(value: unknown): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Client-side ticket filter. NinjaOne's board-run endpoint does not reliably
+ * support server-side filtering by status, client, or device — sending those
+ * filters throws a generic 400 (issues #60, #61) — so matching happens here.
+ *
+ * Board rows carry `status` as an object ({ statusId, displayName }), the client
+ * as `clientId`, and the device as `nodeId`; the single-ticket endpoint uses a
+ * plain status string and `organizationId`/`deviceId`, so all shapes are checked.
+ */
+function ticketMatchesFilters(
+  ticket: Record<string, unknown>,
+  status: string | undefined,
+  organizationId: number | undefined,
+  deviceId: number | undefined
+): boolean {
+  if (status !== undefined) {
+    const s = ticket.status as { displayName?: string; name?: string } | string | undefined;
+    const label = typeof s === "string" ? s : (s?.displayName ?? s?.name ?? "");
+    if (normalizeStatus(label) !== normalizeStatus(status)) return false;
+  }
+  if (organizationId !== undefined) {
+    const org = ticket.clientId ?? ticket.organizationId;
+    if (org !== organizationId) return false;
+  }
+  if (deviceId !== undefined) {
+    const node = ticket.nodeId ?? ticket.deviceId;
+    if (node !== deviceId) return false;
+  }
+  return true;
+}
+
+/** Next-page cursor for board-run pagination: the API's metadata cursor, else the max row id. */
+function ticketPageCursor(
+  response: unknown,
+  tickets: Array<Record<string, unknown>>
+): number {
+  const meta = (response as { metadata?: { lastCursorId?: unknown } } | null)?.metadata;
+  if (meta && typeof meta.lastCursorId === "number") return meta.lastCursorId;
+  const ids = tickets.map((t) => Number(t.id)).filter((n) => Number.isFinite(n));
+  return ids.length ? Math.max(...ids) : 0;
+}
+
+/**
  * Get ticket domain tools
  */
 function getTools(): Tool[] {
@@ -21,7 +83,11 @@ function getTools(): Tool[] {
         "List tickets from a ticket board, filterable by status, organization, or device. " +
         "Requires board_id: NinjaOne queries tickets per board and board IDs vary by tenant " +
         "(board 1 is NOT always the 'All Tickets' board). Discover board IDs with " +
-        "ninjaone_tickets_boards_list first.",
+        "ninjaone_tickets_boards_list first. NOTE: status/organization/device filters are " +
+        "applied client-side within one board page (NinjaOne's board API cannot filter by " +
+        "them server-side), so the response reports `count` (matches in this page) separately " +
+        "from `scanned`, plus `hasMore`/`cursor` — page through until hasMore is false to get " +
+        "every match; never treat one page's count as a board-wide total.",
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -35,18 +101,27 @@ function getTools(): Tool[] {
           status: {
             type: "string",
             enum: ["OPEN", "IN_PROGRESS", "WAITING", "CLOSED"],
+            description:
+              "Filter by status, matched client-side against each ticket's status display name. " +
+              "Custom board statuses whose names differ from these values won't match.",
           },
           organization_id: {
             type: "number",
+            description: "Filter by organization (ticket clientId), matched client-side.",
           },
           device_id: {
             type: "number",
+            description: "Filter by linked device (ticket nodeId), matched client-side.",
           },
           limit: {
             type: "number",
+            description:
+              "Board page size (default 50). A full page sets hasMore=true and returns a cursor.",
           },
           cursor: {
             type: "string",
+            description:
+              "Pagination cursor from a previous response's cursor field (the board's lastCursorId).",
           },
         },
         required: ["board_id"],
@@ -208,30 +283,86 @@ async function handleCall(
 
       const limit = (args.limit as number) || 50;
       const cursor = args.cursor as string | undefined;
+      const statusFilter = args.status as string | undefined;
+      const organizationId = args.organization_id as number | undefined;
+      const deviceId = args.device_id as number | undefined;
+      const filtersActive =
+        statusFilter !== undefined ||
+        organizationId !== undefined ||
+        deviceId !== undefined;
+
       logger.info("API call: tickets.list", {
-        status: args.status,
-        organizationId: args.organization_id,
-        deviceId: args.device_id,
-        boardId: args.board_id,
+        status: statusFilter,
+        organizationId,
+        deviceId,
+        boardId,
         limit,
         cursor,
+        clientSideFilter: filtersActive,
       });
 
+      // NinjaOne's board-run endpoint (POST .../board/{id}/run) does not reliably
+      // support server-side filtering by status, client, or device — passing those
+      // filters throws a generic "Bad request" that is indistinguishable from an
+      // auth failure, and in the wild that silently masqueraded as "zero matching
+      // tickets" (issues #60, #61). So never send them to the API: fetch the board
+      // page and filter in code, exactly as NinjaOne's own integrations do.
       const response = await client.tickets.list({
-        status: args.status as TicketStatus | undefined,
-        organizationId: args.organization_id as number | undefined,
-        deviceId: args.device_id as number | undefined,
         boardId,
         pageSize: limit,
         lastCursorId: cursor !== undefined ? Number(cursor) : undefined,
       });
-      logger.debug("API response: tickets.list", { count: response.tickets?.length });
+
+      if (!filtersActive) {
+        // No filter requested → return the board page unchanged.
+        logger.debug("API response: tickets.list", {
+          count: extractTickets(response).length,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        };
+      }
+
+      const rawTickets = extractTickets(response);
+      const tickets = rawTickets.filter((t) =>
+        ticketMatchesFilters(t, statusFilter, organizationId, deviceId)
+      );
+      // A page exactly the size of the limit means the board almost certainly has
+      // more tickets, so surface it — otherwise a caller (or an LLM) mistakes one
+      // page's matches for the board-wide total, the exact failure behind #61.
+      const hasMore = rawTickets.length === limit;
+      const nextCursor = hasMore
+        ? String(ticketPageCursor(response, rawTickets))
+        : undefined;
+      logger.debug("API response: tickets.list", {
+        scanned: rawTickets.length,
+        matched: tickets.length,
+        hasMore,
+      });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(response, null, 2),
+            text: JSON.stringify(
+              {
+                tickets,
+                count: tickets.length,
+                scanned: rawTickets.length,
+                hasMore,
+                cursor: nextCursor,
+                filter: { status: statusFilter, organizationId, deviceId },
+                note:
+                  "Tickets are filtered client-side within a single board page — " +
+                  "NinjaOne's board API cannot filter by status/organization/device " +
+                  "server-side. `count` is the matches in THIS page only, not a " +
+                  "board-wide total. When `hasMore` is true, pass `cursor` back to " +
+                  "scan the next page, and keep going until `hasMore` is false to " +
+                  "see every match.",
+              },
+              null,
+              2
+            ),
           },
         ],
       };


### PR DESCRIPTION
## Summary

Fixes two related filter bugs reported against the released MCP server (both from the same reporter, part of a "silently wrong/incomplete filtered data" pattern).

- **#61** — `status` on `ninjaone_tickets_list` always threw `Bad request`, even for valid values.
- **#60** — `organization_id` was silently ignored on `ninjaone_devices_list` and threw `Bad request` on `ninjaone_tickets_list`.

The tickets failure was genuinely dangerous: the generic `Bad request` (the SDK maps *any* non-validation 400 to an **authentication** error) was indistinguishable from an auth blip, so the reporter's downstream sync silently treated it as **zero open tickets** across 5 of 6 client accounts for weeks (real counts 1–44).

## Root cause (verified against the NinjaOne v2 API + SDK v2.0.1)

- **Tickets:** `POST /v2/ticketing/trigger/board/{id}/run` does **not** reliably support server-side filtering by status/client/device — the accepted filter `field` tokens are undocumented and every production NinjaOne integration filters client-side. The SDK sent a `{field,operator,value}` filter body the API rejects with a 400.
- **Devices:** `GET /v2/devices` has no `organizationId` param; the SDK compiles it into `df=org=<id>`, but NinjaOne **silently drops that filter** often enough to be unusable (a dropped filter returns the entire fleet — exactly #60).

## Fix

- **Tickets:** never send status/org/device filters to the board API (removes the 400). Fetch the board page and filter **client-side** — status against each row's `status.displayName`, org against `clientId`, device against `nodeId`. Response now separates `count` (matches in this page) from `scanned` and surfaces `hasMore`/`cursor`, so a single page's matches can never be mistaken for a board-wide total.
- **Devices:** route `organization_id` through the dedicated `GET /v2/organization/{id}/devices` endpoint (org scoped via the URL **path**, which can't be dropped). `device_class`/`online` are filtered client-side on that path since it has no `df`. The no-org path (df-based class/online filtering) is unchanged.

## Tests / verification

- `npm test` — 128 pass (7 new). New tests drive the exact handler paths: tickets never forward server-side filters and filter rows correctly (status-object/`clientId`/`nodeId` shapes); devices route org → `listByOrganization` and never emit `df=org`; pagination metadata verified on both.
- `tsc --noEmit`, `eslint`, and `npm run build` all clean.
- No live-tenant verification: exercising a customer NinjaOne tenant isn't appropriate here, so the SDK boundary is mocked with the real board-row/device shapes confirmed from the NinjaOne OpenAPI spec + Device Filter Syntax PDF.

## Notes / follow-ups (SDK, separate repo)

The deeper root causes live in `@wyre-technology/node-ninjaone` and are worth separate issues: (1) `tickets.list` sends a board-run filter body NinjaOne rejects; (2) the HTTP client maps a generic 400 to `NinjaOneAuthenticationError` ("Bad request - invalid credentials or parameters"), which is what made the failure look like an auth problem. This PR resolves both user-facing issues without waiting on an SDK release.

Fixes #61
Fixes #60