### PR TITLE
fix: ignore unresolved config placeholder in NINJAONE_REGION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 ### Fixed
 
+- An unresolved MCPB/DXT config placeholder in `NINJAONE_REGION` (e.g. the
+  literal `${user_config.ninjaone_region}` that Claude Desktop injects when the
+  optional region field is left blank) no longer makes `getCredentials()` return
+  `null` — which surfaced as "No API credentials provided" on **every** tool call
+  and misdirected users to their (correct) credentials. A blank, whitespace, or
+  placeholder region now falls back to `us`, aligning the stdio env path with the
+  already-graceful gateway-header and Worker paths (`isValidRegion(x) ? x : "us"`).
+  Mirrors itglue-mcp #73.
 - `ninjaone_tickets_list` no longer throws a generic `Bad request` when a
   `status`, `organization_id`, or `device_id` filter is supplied
   ([#61](https://github.com/wyre-technology/ninjaone-mcp/issues/61),

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -83,13 +83,54 @@ describe("NinjaOne Client Utilities", () => {
       expect(creds).toBeNull();
     });
 
-    it("should return null for invalid region", () => {
+    it("should fall back to US region for an invalid region", () => {
       process.env.NINJAONE_CLIENT_ID = "test-id";
       process.env.NINJAONE_CLIENT_SECRET = "test-secret";
       process.env.NINJAONE_REGION = "invalid";
 
       const creds = getCredentials();
-      expect(creds).toBeNull();
+      expect(creds).toEqual({
+        clientId: "test-id",
+        clientSecret: "test-secret",
+        region: "us",
+        baseUrl: "https://app.ninjarmm.com",
+      });
+    });
+
+    // Regression: MCPB/DXT desktop bundles map NINJAONE_REGION to
+    // "${user_config.ninjaone_region}". When this OPTIONAL field is left blank,
+    // Claude Desktop injects the LITERAL placeholder string (truthy, not empty),
+    // which used to bypass the `|| "us"` default, fail isValidRegion(), and make
+    // getCredentials() return null — surfacing as "No API credentials provided"
+    // on every tool call and misdirecting the user to their (correct) credentials.
+    it("should treat an unresolved config placeholder region as US (not null)", () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_REGION = "${user_config.ninjaone_region}";
+
+      const creds = getCredentials();
+      expect(creds).not.toBeNull();
+      expect(creds).toEqual({
+        clientId: "test-id",
+        clientSecret: "test-secret",
+        region: "us",
+        baseUrl: "https://app.ninjarmm.com",
+      });
+    });
+
+    it("should fall back to US region for a blank or whitespace region", () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+
+      for (const value of ["", "   "]) {
+        process.env.NINJAONE_REGION = value;
+        expect(getCredentials()).toEqual({
+          clientId: "test-id",
+          clientSecret: "test-secret",
+          region: "us",
+          baseUrl: "https://app.ninjarmm.com",
+        });
+      }
     });
 
     it("should return credentials with default US region", () => {
@@ -198,6 +239,24 @@ describe("NinjaOne Client Utilities", () => {
       const client2 = await getClient();
 
       expect(client1).not.toBe(client2);
+    });
+
+    // Regression: before the fix, a left-blank optional region arrived as the
+    // literal "${user_config.ninjaone_region}", failed region validation, made
+    // getCredentials() return null, and getClient() rejected with
+    // "No API credentials provided" on every tool call. It must now resolve.
+    it("should not reject with the credentials error when the region is an unresolved placeholder", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_REGION = "${user_config.ninjaone_region}";
+
+      let caught: unknown;
+      try {
+        await getClient();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeUndefined();
     });
   });
 

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -16,6 +16,13 @@ export interface NinjaOneCredentials {
   baseUrl: string;
 }
 
+/**
+ * Matches an unresolved MCPB/DXT config placeholder, e.g. "${user_config.ninjaone_region}".
+ * When an optional user_config field is left blank, Claude Desktop injects the literal
+ * placeholder string (not empty, not omitted) into the env var. Treat it as unset.
+ */
+const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
+
 let _client: NinjaOneClient | null = null;
 let _credentials: NinjaOneCredentials | null = null;
 
@@ -80,7 +87,6 @@ export function getCredentials(): NinjaOneCredentials | null {
 
   const clientId = process.env.NINJAONE_CLIENT_ID;
   const clientSecret = process.env.NINJAONE_CLIENT_SECRET;
-  const regionEnv = process.env.NINJAONE_REGION?.toLowerCase() || "us";
 
   if (!clientId || !clientSecret) {
     logger.warn("Missing credentials", {
@@ -90,12 +96,21 @@ export function getCredentials(): NinjaOneCredentials | null {
     return null;
   }
 
+  // Ignore a blank value or an unresolved MCPB config placeholder so an optional,
+  // left-blank region falls back to "us" — mirroring the gateway/worker paths that
+  // already do `isValidRegion(x) ? x : "us"` instead of failing hard.
+  const rawRegion = process.env.NINJAONE_REGION?.trim();
+  const regionEnv =
+    rawRegion && !CONFIG_PLACEHOLDER.test(rawRegion) ? rawRegion.toLowerCase() : "us";
+
   if (!isValidRegion(regionEnv)) {
-    logger.warn("Invalid region configured", { region: regionEnv, valid: ["us", "eu", "oc", "ca", "us2", "fed"] });
-    return null;
+    logger.warn("Invalid region configured, defaulting to us", {
+      region: regionEnv,
+      valid: ["us", "eu", "oc", "ca", "us2", "fed"],
+    });
   }
 
-  const region = regionEnv as NinjaOneRegion;
+  const region = isValidRegion(regionEnv) ? regionEnv : "us";
   const baseUrl = getBaseUrlForRegion(region);
 
   return { clientId, clientSecret, region, baseUrl };


### PR DESCRIPTION
## Summary

Fixes a config-placeholder bug in the **stdio env ingress**. This is a fleet-wide fix mirroring [itglue-mcp #73](https://github.com/wyre-technology/itglue-mcp/issues/73).

MCPB/DXT desktop bundles map env vars to `${user_config.X}` in `manifest.json`. When an **optional** `user_config` field is left blank, Claude Desktop injects the **literal** string `${user_config.X}` into the env var — not empty, not omitted.

`NINJAONE_REGION` is optional (`manifest.json` maps it to `${user_config.ninjaone_region}`, `required: false`). When a user leaves it blank:

1. `NINJAONE_REGION` becomes the literal `${user_config.ninjaone_region}` (a truthy string).
2. In `getCredentials()`, `process.env.NINJAONE_REGION?.toLowerCase() || "us"` did **not** fall back to `"us"` because the placeholder is truthy.
3. `isValidRegion(...)` (valid = `us`/`eu`/`oc`/`ca`/`us2`/`fed`) fails, so `getCredentials()` returns **null**.
4. `getClient()` then throws **"No API credentials provided..."** on **every** tool call — misdirecting the user to their (correct) credentials.

The gateway-header path (`mcp-server.ts`) and the Worker path already degrade gracefully with `isValidRegion(x) ? x : "us"`. Only the stdio env path was broken.

## The fix

`src/utils/client.ts` `getCredentials()` now sanitizes `NINJAONE_REGION`:

- Trims the value; treats a blank string or an unresolved `${...}` placeholder as unset (falls back to `"us"`).
- Replaces the hard `return null` on an unknown region with the same graceful `isValidRegion(regionEnv) ? regionEnv : "us"` fallback the gateway/worker paths already use, so an unknown/placeholder region can never return null.

No change to `manifest.json`.

## Tests

Added focused regression tests in `src/__tests__/client.test.ts`:

- **getCredentials**: placeholder region `${user_config.ninjaone_region}` → valid creds with region `us` (not null); blank/whitespace region → `us`; invalid region now falls back to `us` (was: null).
- **getClient**: with valid client ID/secret and a placeholder region, `getClient()` no longer rejects with the credentials error.

Verified the four fix-dependent assertions all **fail** against the pre-fix source and **pass** with the fix.

## Local checks (all green)

- `npm ci` — ok
- `npm run lint` — ok
- `npm run typecheck` — ok
- `npm run build` — ok
- `npm test` — **131 passed** (10 files)

## Do not merge

Opening for review as part of the fleet-wide rollout.
