### PR TITLE
feat: migrate to MCP SDK v2 with dual-era (backward-compatible) serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,32 @@
 
 ### Changed
 
+- **Migrated from `@modelcontextprotocol/sdk` v1 (1.29.0) to the v2 beta SDK**
+  (`@modelcontextprotocol/server` + `@modelcontextprotocol/node`,
+  2.0.0-beta.5) with **dual-era serving**: one endpoint now serves both
+  legacy 2025-era clients (classic `initialize` handshake) and modern
+  2026-07-28 envelope clients.
+  - All entrypoints consume the one shared server factory (`mcp-server.ts`):
+    stdio serves via `serveStdio`, Node HTTP via `createMcpHandler` +
+    `toNodeHandler`, and the Cloudflare Worker via the same
+    `createMcpHandler`. Legacy traffic is served with `legacy: 'stateless'`
+    (a fresh server instance per request — the same stateless idiom this
+    server already used), so existing clients keep working unchanged.
+  - The gateway credential-header contract is unchanged: `X-Ninja-Client-ID`,
+    `X-Ninja-Client-Secret`, and optional `X-Ninja-Region` are still read per
+    request in gateway mode (missing headers still answer 401 with the same
+    body), and the tool surface served by `tools/list` is identical (25 tools,
+    same names, same input schemas, same `_meta`).
+  - Wire note: responses to legacy-era POSTs are now delivered as SSE
+    (`text/event-stream`) instead of a single JSON body. Both encodings are
+    part of the streamable-HTTP transport spec and every conformant client
+    accepts both (clients already send `Accept: application/json,
+    text/event-stream`); legacy-era GET/DELETE session operations now answer
+    405, as stateless serving always implied.
+  - A dual-era smoke test (`scripts/smoke-dual-era.mjs`) proves both eras
+    against the built server: a hand-crafted 2025-03-26 JSON-RPC client and a
+    v2 `@modelcontextprotocol/client` StreamableHTTP client both list the
+    same 25 tools.
 - **Breaking:** `ninjaone_tickets_list` now requires `board_id` instead of
   silently falling back to board 1 ([#54](https://github.com/wyre-technology/ninjaone-mcp/issues/54)).
   Board IDs are tenant-specific — on multi-board tenants the old fallback could

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@modelcontextprotocol/client": "^2.0.0-beta.5",
         "@modelcontextprotocol/ext-apps": "^1.7.3",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
@@ -853,6 +854,25 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.5.tgz",
+      "integrity": "sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@modelcontextprotocol/core": {
       "version": "2.0.0-beta.5",
@@ -4186,7 +4206,6 @@
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -4200,7 +4219,6 @@
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -5195,7 +5213,6 @@
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -8256,7 +8273,6 @@
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.4.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/node": "^2.0.0-beta.5",
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
         "@wyre-technology/node-ninjaone": "^2.0.1"
       },
       "bin": {
@@ -853,6 +854,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0-beta.5.tgz",
+      "integrity": "sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/ext-apps": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
@@ -883,11 +896,34 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0-beta.5.tgz",
+      "integrity": "sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0-beta.5",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -921,6 +957,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.5.tgz",
+      "integrity": "sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0-beta.5",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -2680,7 +2729,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -2740,7 +2791,9 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2756,7 +2809,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2870,7 +2925,9 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
@@ -2914,7 +2971,9 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2923,7 +2982,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2936,7 +2997,9 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -3211,7 +3274,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3224,7 +3289,9 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3311,7 +3378,9 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3320,7 +3389,9 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -3336,7 +3407,9 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -3380,6 +3453,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3423,6 +3497,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3457,7 +3532,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3492,7 +3569,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -3516,7 +3595,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3536,7 +3617,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3736,7 +3819,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3745,7 +3830,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3761,7 +3848,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -3825,7 +3914,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4082,7 +4173,9 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4091,7 +4184,9 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -4103,7 +4198,9 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -4146,7 +4243,9 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4189,7 +4288,9 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
       "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.0.1"
       },
@@ -4224,6 +4325,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4244,6 +4346,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4254,7 +4357,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -4302,7 +4406,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -4391,7 +4497,9 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4400,7 +4508,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -4450,7 +4560,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4495,7 +4607,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -4519,7 +4633,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -4586,7 +4702,9 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4637,7 +4755,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4649,7 +4769,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4672,6 +4794,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4706,7 +4829,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -4764,7 +4889,9 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4865,6 +4992,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -4895,7 +5023,9 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
       "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -4904,7 +5034,9 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -4986,7 +5118,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5025,6 +5159,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/issue-parser": {
@@ -5058,7 +5193,9 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5108,13 +5245,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5372,7 +5513,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5381,7 +5524,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5403,7 +5548,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5452,7 +5599,9 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5461,7 +5610,9 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -5497,6 +5648,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5541,7 +5693,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7711,6 +7865,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7720,7 +7875,9 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7746,7 +7903,9 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -7758,7 +7917,9 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8003,7 +8164,9 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8022,6 +8185,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8031,7 +8195,9 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
       "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -8088,7 +8254,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -8243,7 +8411,9 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -8266,7 +8436,9 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -8281,7 +8453,9 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8290,7 +8464,9 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -8471,7 +8647,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8535,7 +8713,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -8558,7 +8738,9 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-release": {
       "version": "25.0.3",
@@ -8919,7 +9101,9 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -8945,7 +9129,9 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -8964,12 +9150,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8982,6 +9171,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8991,7 +9181,9 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -9010,7 +9202,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -9026,7 +9220,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -9044,7 +9240,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -9276,7 +9474,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9638,7 +9838,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -9683,7 +9885,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -10029,7 +10233,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10076,7 +10282,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -10323,6 +10531,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10444,7 +10653,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -10574,7 +10785,9 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -46,12 +46,13 @@
   },
   "homepage": "https://github.com/wyre-technology/ninjaone-mcp#readme",
   "dependencies": {
-    "@wyre-technology/node-ninjaone": "^2.0.1",
     "@modelcontextprotocol/node": "^2.0.0-beta.5",
-    "@modelcontextprotocol/server": "^2.0.0-beta.5"
+    "@modelcontextprotocol/server": "^2.0.0-beta.5",
+    "@wyre-technology/node-ninjaone": "^2.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@modelcontextprotocol/client": "^2.0.0-beta.5",
     "@modelcontextprotocol/ext-apps": "^1.7.3",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
   },
   "homepage": "https://github.com/wyre-technology/ninjaone-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@wyre-technology/node-ninjaone": "^2.0.1"
+    "@wyre-technology/node-ninjaone": "^2.0.1",
+    "@modelcontextprotocol/node": "^2.0.0-beta.5",
+    "@modelcontextprotocol/server": "^2.0.0-beta.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/smoke-dual-era.mjs
+++ b/scripts/smoke-dual-era.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Dual-era smoke test: proves one HTTP endpoint serves BOTH protocol eras.
+ *
+ * Starts the built server (dist/index.js — run `npm run build` first) on a
+ * local port with dummy env credentials, then:
+ *  (a) drives a LEGACY client: hand-crafted 2025-era JSON-RPC POSTs —
+ *      initialize (protocolVersion 2025-03-26) → notifications/initialized →
+ *      tools/list — asserting a valid InitializeResult and >0 tools;
+ *  (b) drives a MODERN client: @modelcontextprotocol/client (v2) over
+ *      StreamableHTTPClientTransport → tools/list — asserting the same
+ *      tool count.
+ *
+ * Exits non-zero on any failure.
+ */
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PORT = Number(process.env.SMOKE_PORT ?? 8931);
+const BASE = `http://127.0.0.1:${PORT}`;
+const MCP_URL = `${BASE}/mcp`;
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+let failed = false;
+function check(condition, label, detail) {
+  if (condition) {
+    console.log(`  ok    ${label}`);
+  } else {
+    failed = true;
+    console.error(`  FAIL  ${label}${detail !== undefined ? ` — ${JSON.stringify(detail)}` : ""}`);
+  }
+}
+
+/** Decode a JSON-RPC message from a streamable-HTTP response (JSON or SSE). */
+async function mcpJson(res) {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    const messages = (await res.text())
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    return messages[messages.length - 1];
+  }
+  return res.json();
+}
+
+async function legacyPost(body) {
+  return fetch(MCP_URL, {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+async function waitForHealth(timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE}/health`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await delay(200);
+  }
+  throw new Error(`server did not become healthy on ${BASE} within ${timeoutMs}ms`);
+}
+
+async function legacyEra() {
+  console.log("[legacy era] classic 2025-03-26 JSON-RPC sequence");
+
+  const initRes = await legacyPost({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "smoke-legacy", version: "0.0.0" },
+    },
+  });
+  check(initRes.status === 200, `initialize HTTP 200 (got ${initRes.status})`);
+  const init = await mcpJson(initRes);
+  check(typeof init?.result?.protocolVersion === "string", "InitializeResult.protocolVersion present", init);
+  check(init?.result?.serverInfo?.name === "ninjaone-mcp", "InitializeResult.serverInfo.name === ninjaone-mcp", init?.result?.serverInfo);
+  check(typeof init?.result?.capabilities === "object" && init?.result?.capabilities !== null, "InitializeResult.capabilities present");
+
+  const notifRes = await legacyPost({ jsonrpc: "2.0", method: "notifications/initialized" });
+  check(notifRes.status === 202, `notifications/initialized HTTP 202 (got ${notifRes.status})`);
+
+  const listRes = await legacyPost({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  check(listRes.status === 200, `tools/list HTTP 200 (got ${listRes.status})`);
+  const list = await mcpJson(listRes);
+  const tools = list?.result?.tools ?? [];
+  check(tools.length > 0, `tools/list returned ${tools.length} tools (>0)`);
+  return tools.length;
+}
+
+async function modernEra() {
+  console.log("[modern era] @modelcontextprotocol/client v2 over StreamableHTTPClientTransport");
+  const client = new Client({ name: "smoke-modern", version: "0.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL));
+  await client.connect(transport);
+  const { tools } = await client.listTools();
+  check(tools.length > 0, `tools/list returned ${tools.length} tools (>0)`);
+  await client.close();
+  return tools.length;
+}
+
+async function main() {
+  console.log(`Starting server on ${BASE} ...`);
+  const child = spawn("node", [resolve(ROOT, "dist/index.js")], {
+    env: {
+      ...process.env,
+      MCP_TRANSPORT: "http",
+      MCP_HTTP_PORT: String(PORT),
+      MCP_HTTP_HOST: "127.0.0.1",
+      NINJAONE_CLIENT_ID: "smoke-dummy-id",
+      NINJAONE_CLIENT_SECRET: "smoke-dummy-secret",
+      NINJAONE_REGION: "us",
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+
+  try {
+    await waitForHealth();
+
+    const legacyCount = await legacyEra();
+    const modernCount = await modernEra();
+    check(
+      legacyCount === modernCount,
+      `both eras list the same tool count (legacy=${legacyCount}, modern=${modernCount})`
+    );
+  } finally {
+    child.kill("SIGTERM");
+  }
+
+  if (failed) {
+    console.error("\nsmoke-dual-era: FAILED");
+    process.exit(1);
+  }
+  console.log("\nsmoke-dual-era: PASS — one endpoint, both eras served");
+}
+
+main().catch((error) => {
+  console.error("smoke-dual-era: FAILED —", error);
+  process.exit(1);
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared test helpers (not collected by vitest — no .test suffix).
+ */
+
+/**
+ * Decode the JSON-RPC message from a streamable-HTTP response body.
+ *
+ * The v2 SDK's legacy stateless serving answers POSTs as SSE
+ * (`text/event-stream`) rather than v1's single JSON body
+ * (`enableJsonResponse: true`), so tests accept both encodings — exactly
+ * like a real streamable-HTTP client does.
+ */
+export async function mcpJson(res: Response): Promise<unknown> {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    const messages = (await res.text())
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => JSON.parse(line.slice(5).trim()) as unknown);
+    // Stateless per-request serving carries exactly one response message.
+    return messages[messages.length - 1];
+  }
+  return res.json();
+}

--- a/src/__tests__/mcp-apps.test.ts
+++ b/src/__tests__/mcp-apps.test.ts
@@ -20,6 +20,7 @@ import {
   MCP_APP_RESOURCE_MIME,
 } from "../alert-card.js";
 import { ALERT_CARD_HTML } from "../generated/alert-card-html.js";
+import { mcpJson } from "./helpers.js";
 
 const { mockAlertsGet, mockAlertsReset, mockDevicesGet, mockOrgsGet } = vi.hoisted(() => ({
   mockAlertsGet: vi.fn(),
@@ -95,7 +96,7 @@ describe("MCP Apps alert card", () => {
         params: {},
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: {
           tools?: { name: string; _meta?: Record<string, unknown> }[];
         };
@@ -117,7 +118,7 @@ describe("MCP Apps alert card", () => {
         method: "tools/list",
         params: {},
       });
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: {
           tools?: { name: string; _meta?: Record<string, unknown> }[];
         };
@@ -140,7 +141,7 @@ describe("MCP Apps alert card", () => {
         params: {},
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { resources?: { uri: string; mimeType?: string }[] };
       };
       const card = body.result?.resources?.find(
@@ -157,7 +158,7 @@ describe("MCP Apps alert card", () => {
         params: { uri: ALERT_CARD_RESOURCE_URI },
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { contents?: { uri: string; mimeType?: string; text?: string }[] };
       };
       const content = body.result?.contents?.[0];
@@ -178,7 +179,7 @@ describe("MCP Apps alert card", () => {
         method: "resources/read",
         params: { uri: ALERT_CARD_RESOURCE_URI },
       });
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { contents?: { text?: string }[] };
       };
       const text = body.result?.contents?.[0]?.text ?? "";
@@ -193,7 +194,7 @@ describe("MCP Apps alert card", () => {
         method: "resources/read",
         params: { uri: "ui://ninjaone/nope.html" },
       });
-      const body = (await res.json()) as { error?: { message?: string } };
+      const body = (await mcpJson(res)) as { error?: { message?: string } };
       expect(body.error?.message).toMatch(/Unknown resource/);
     });
   });
@@ -223,7 +224,7 @@ describe("MCP Apps alert card", () => {
         CREDS_ENV
       );
       expect(res.status).toBe(200);
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { isError?: boolean; content?: { text?: string }[] };
       };
       expect(body.result?.isError).toBeFalsy();
@@ -260,7 +261,7 @@ describe("MCP Apps alert card", () => {
         },
         CREDS_ENV
       );
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { isError?: boolean; content?: { text?: string }[] };
       };
       expect(body.result?.isError).toBeFalsy();
@@ -286,7 +287,7 @@ describe("MCP Apps alert card", () => {
         },
         CREDS_ENV
       );
-      const body = (await res.json()) as {
+      const body = (await mcpJson(res)) as {
         result?: { isError?: boolean; content?: { text?: string }[] };
       };
       expect(body.result?.isError).toBeFalsy();

--- a/src/__tests__/worker.test.ts
+++ b/src/__tests__/worker.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect } from "vitest";
 import worker, { type Env } from "../worker.js";
+import { mcpJson } from "./helpers.js";
 
 const MCP_HEADERS = {
   Accept: "application/json, text/event-stream",
@@ -58,14 +59,14 @@ describe("Cloudflare Worker entrypoint", () => {
       },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+    const body = (await mcpJson(res)) as { result?: { serverInfo?: { name?: string } } };
     expect(body.result?.serverInfo?.name).toBe("ninjaone-mcp");
   });
 
   it("lists all tools without credentials", async () => {
     const res = await mcp({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { result?: { tools?: { name: string }[] } };
+    const body = (await mcpJson(res)) as { result?: { tools?: { name: string }[] } };
     const names = (body.result?.tools ?? []).map((t) => t.name);
     expect(names).toContain("ninjaone_navigate");
     expect(names).toContain("ninjaone_status");
@@ -80,7 +81,7 @@ describe("Cloudflare Worker entrypoint", () => {
       params: { name: "ninjaone_devices_list", arguments: {} },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
+    const body = (await mcpJson(res)) as {
       result?: { isError?: boolean; content?: { text?: string }[] };
     };
     expect(body.result?.isError).toBe(true);

--- a/src/domains/alerts.ts
+++ b/src/domains/alerts.ts
@@ -3,8 +3,7 @@
  *
  * Provides tools for alert operations in NinjaOne.
  */
-
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import type { Alert, AlertSeverity, AlertSourceType, NinjaOneClient } from "@wyre-technology/node-ninjaone";
 import { getClient } from "../utils/client.js";

--- a/src/domains/devices.ts
+++ b/src/domains/devices.ts
@@ -3,8 +3,7 @@
  *
  * Provides tools for device operations in NinjaOne.
  */
-
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 import type { DeviceNodeClass } from "@wyre-technology/node-ninjaone";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import { getClient } from "../utils/client.js";

--- a/src/domains/organizations.ts
+++ b/src/domains/organizations.ts
@@ -3,8 +3,7 @@
  *
  * Provides tools for organization operations in NinjaOne.
  */
-
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -3,8 +3,7 @@
  *
  * Provides tools for ticket operations in NinjaOne.
  */
-
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import type { TicketStatus, TicketPriority, TicketType } from "@wyre-technology/node-ninjaone";
 import { getClient } from "../utils/client.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,11 @@
  * - stdio (default): For local Claude Desktop / CLI usage
  * - http: For hosted deployment with optional gateway auth
  *
- * The Cloudflare Workers entrypoint lives in `worker.ts` and reuses the same
- * `createMcpServer()` factory from `mcp-server.ts`.
+ * Both entrypoints serve dual protocol eras via the v2 SDK serving entries:
+ * legacy 2025-era clients (classic `initialize` handshake) are served
+ * statelessly per request, and modern 2026-07-28 envelope clients natively —
+ * from the same server factory (`mcp-server.ts`). The Cloudflare Workers
+ * entrypoint lives in `worker.ts` and reuses that factory too.
  *
  * Credentials are provided via environment variables:
  * - NINJAONE_CLIENT_ID
@@ -24,33 +27,52 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { createMcpHandler } from "@modelcontextprotocol/server";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { toNodeHandler } from "@modelcontextprotocol/node";
 import {
   createMcpServer,
+  makeMcpServerFactory,
   resolveGatewayCredentials,
-  type NinjaOneCredentials,
 } from "./mcp-server.js";
 import { logger } from "./utils/logger.js";
 
 /**
- * Start the server with stdio transport (default)
+ * Start the server with stdio transport (default).
+ * `serveStdio` owns the era decision: a 2025-era `initialize` pins the
+ * connection legacy; modern envelope openings are served natively.
  */
-async function startStdioTransport(): Promise<void> {
-  const server = await createMcpServer();
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+function startStdioTransport(): void {
+  serveStdio(() => createMcpServer(), {
+    onerror: (error) => logger.error("stdio serving error", { error: error.message }),
+  });
   logger.info("NinjaOne MCP server running on stdio (flattened mode)");
 }
 
 /**
- * Start the server with HTTP Streamable transport.
- * Each request gets a fresh Server + Transport (stateless).
+ * Start the server with HTTP serving via `createMcpHandler`.
+ * The handler is created once; its factory runs per request (stateless),
+ * exactly like the previous per-request Server + Transport wiring.
  */
 async function startHttpTransport(): Promise<void> {
   const port = parseInt(process.env.MCP_HTTP_PORT || "8080", 10);
   const host = process.env.MCP_HTTP_HOST || "0.0.0.0";
   const isGatewayMode = process.env.AUTH_MODE === "gateway";
+
+  // legacy: 'stateless' (also the default) is the dual-era posture: 2025-era
+  // traffic is answered per-request statelessly, modern 2026-07-28 envelope
+  // traffic natively. Never use legacy: 'reject' here — it would turn away
+  // every pre-envelope client.
+  const mcpHandler = createMcpHandler(
+    makeMcpServerFactory({ gatewayMode: isGatewayMode }),
+    {
+      legacy: "stateless",
+      onerror: (error) => logger.error("MCP serving error", { error: error.message }),
+    }
+  );
+  const handleMcpRequest = toNodeHandler(mcpHandler, {
+    onerror: (error) => logger.error("MCP request adapter error", { error: error.message }),
+  });
 
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
@@ -67,9 +89,8 @@ async function startHttpTransport(): Promise<void> {
 
     // MCP endpoint
     if (url.pathname === "/mcp") {
-      let credOverrides: NinjaOneCredentials | undefined;
       if (isGatewayMode) {
-        const { creds, error } = resolveGatewayCredentials(
+        const { error } = resolveGatewayCredentials(
           (name) => req.headers[name] as string | undefined
         );
         if (error) {
@@ -84,23 +105,11 @@ async function startHttpTransport(): Promise<void> {
           );
           return;
         }
-        credOverrides = creds;
       }
 
-      // Create fresh server + transport per request (stateless)
-      const server = await createMcpServer(credOverrides);
-      const transport = new NodeStreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      });
-
-      res.on("close", () => {
-        transport.close();
-        server.close();
-      });
-
-      await server.connect(transport);
-      transport.handleRequest(req, res);
+      // Per-request credential binding happens inside the factory (it reads
+      // the gateway headers from ctx.requestInfo on every request).
+      await handleMcpRequest(req, res);
       return;
     }
 
@@ -121,6 +130,7 @@ async function startHttpTransport(): Promise<void> {
   // Graceful shutdown
   const shutdown = async () => {
     logger.info("Shutting down NinjaOne MCP server...");
+    await mcpHandler.close();
     await new Promise<void>((resolve, reject) => {
       httpServer.close((err) => (err ? reject(err) : resolve()));
     });
@@ -145,7 +155,7 @@ async function main() {
   if (transportType === "http") {
     await startHttpTransport();
   } else {
-    await startStdioTransport();
+    startStdioTransport();
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,8 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
 import {
   createMcpServer,
   resolveGatewayCredentials,
@@ -89,7 +89,7 @@ async function startHttpTransport(): Promise<void> {
 
       // Create fresh server + transport per request (stateless)
       const server = await createMcpServer(credOverrides);
-      const transport = new StreamableHTTPServerTransport({
+      const transport = new NodeStreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
         enableJsonResponse: true,
       });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,5 +1,17 @@
+/**
+ * Shared MCP server factory for NinjaOne.
+ *
+ * This module is **side-effect free** (importing it never starts a transport),
+ * so it can be reused by every entrypoint:
+ * - `index.ts` — stdio + Node HTTP serving
+ * - `worker.ts` — Cloudflare Workers serving
+ *
+ * All NinjaOne tools are exposed upfront (flat architecture) for universal MCP
+ * client compatibility.
+ */
+
 import { Server } from "@modelcontextprotocol/server";
-import type { Tool } from "@modelcontextprotocol/server";
+import type { McpServerFactory, Tool } from "@modelcontextprotocol/server";
 import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
 import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
 import {
@@ -132,6 +144,33 @@ export function resolveGatewayCredentials(
     getHeader("x-ninja-client-secret"),
     getHeader("x-ninja-region")
   );
+}
+
+/**
+ * Bind `createMcpServer` into the `McpServerFactory` shape the v2 HTTP serving
+ * entry (`createMcpHandler`) consumes. The factory runs once per HTTP request
+ * — the same fresh-instance-per-request stateless idiom this server has always
+ * used — for BOTH protocol eras (legacy 2025 traffic and modern 2026-07-28
+ * envelope traffic).
+ *
+ * In gateway mode the request's X-Ninja-* headers are read from
+ * `ctx.requestInfo`, keeping credentials bound per request. Missing headers
+ * are answered 401 by the HTTP layer before serving ever starts; if a request
+ * slips through without them, tools/call reports the credential error in-band.
+ */
+export function makeMcpServerFactory(options: {
+  gatewayMode: boolean;
+  envCredentials?: NinjaOneCredentials;
+}): McpServerFactory {
+  return (ctx) => {
+    if (options.gatewayMode) {
+      const { creds } = resolveGatewayCredentials(
+        (name) => ctx.requestInfo?.headers.get(name) ?? undefined
+      );
+      return createMcpServer(creds);
+    }
+    return createMcpServer(options.envCredentials);
+  };
 }
 
 /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,23 +1,5 @@
-/**
- * Shared MCP server factory for NinjaOne.
- *
- * This module is **side-effect free** (importing it never starts a transport),
- * so it can be reused by every entrypoint:
- * - `index.ts` — stdio + Node HTTP transport
- * - `worker.ts` — Cloudflare Workers (Web Standard) transport
- *
- * All NinjaOne tools are exposed upfront (flat architecture) for universal MCP
- * client compatibility.
- */
-
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import {
-  CallToolRequestSchema,
-  ListResourcesRequestSchema,
-  ListToolsRequestSchema,
-  ReadResourceRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { Server } from "@modelcontextprotocol/server";
+import type { Tool } from "@modelcontextprotocol/server";
 import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
 import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
 import {
@@ -181,14 +163,14 @@ export async function createMcpServer(
   setServerRef(server);
   registerPromptHandlers(server);
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
+  server.setRequestHandler('tools/list', async () => {
     return { tools: [navigateTool, statusTool, ...allDomainTools] };
   });
 
   // MCP Apps (SEP-1865): the ui:// alert card is static HTML embedded at
   // build time (src/generated/alert-card-html.ts), so it serves identically
   // from stdio, Node HTTP, and the fs-less Cloudflare Workers runtime.
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  server.setRequestHandler('resources/list', async () => {
     return {
       resources: [
         {
@@ -201,7 +183,7 @@ export async function createMcpServer(
     };
   });
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  server.setRequestHandler('resources/read', async (request) => {
     const { uri } = request.params;
     if (uri !== ALERT_CARD_RESOURCE_URI) {
       throw new Error(`Unknown resource: ${uri}`);
@@ -219,7 +201,7 @@ export async function createMcpServer(
     };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler('tools/call', async (request) => {
     const { name, arguments: args } = request.params;
     logger.info("Tool call received", { tool: name, arguments: args });
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,7 +1,7 @@
-import { Server } from "@modelcontextprotocol/server";
-
 // MCP Prompt Handlers for NinjaOne MCP Server
 // Exposes pre-baked prompt templates via ListPrompts and GetPrompt handlers
+
+import { Server } from "@modelcontextprotocol/server";
 
 export function registerPromptHandlers(server: Server): void {
   server.setRequestHandler('prompts/list', async () => ({

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,14 +1,10 @@
+import { Server } from "@modelcontextprotocol/server";
+
 // MCP Prompt Handlers for NinjaOne MCP Server
 // Exposes pre-baked prompt templates via ListPrompts and GetPrompt handlers
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import {
-  ListPromptsRequestSchema,
-  GetPromptRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-
 export function registerPromptHandlers(server: Server): void {
-  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  server.setRequestHandler('prompts/list', async () => ({
     prompts: [
       {
         name: 'device-health-summary',
@@ -46,7 +42,7 @@ export function registerPromptHandlers(server: Server): void {
     ],
   }));
 
-  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  server.setRequestHandler('prompts/get', async (request) => {
     const { name, arguments: args } = request.params;
 
     switch (name) {

--- a/src/utils/server-ref.ts
+++ b/src/utils/server-ref.ts
@@ -2,7 +2,7 @@
  * Shared MCP Server reference for elicitation support.
  * Avoids circular imports by decoupling server instance from domain handlers.
  */
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { Server } from "@modelcontextprotocol/server";
 
 let _server: Server | null = null;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,8 +1,7 @@
 /**
  * Shared types for the NinjaOne MCP server
  */
-
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Tool } from "@modelcontextprotocol/server";
 
 /**
  * Tool call result type - inline definition for MCP SDK compatibility

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -20,8 +20,7 @@
  * `tools/list` and `initialize` work without credentials; only `tools/call`
  * requires them.
  */
-
-import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/server";
 import {
   createMcpServer,
   resolveGatewayCredentials,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,11 +1,13 @@
 /**
  * Cloudflare Workers entry point for the NinjaOne MCP Server.
  *
- * Serves the full MCP server over the Streamable HTTP transport using the SDK's
- * Web Standard transport (Request/Response), which runs natively on Workers.
- * It reuses the exact same `createMcpServer()` factory as the stdio / Node HTTP
- * entrypoints (see `mcp-server.ts`), so there is no second tool implementation
- * to maintain.
+ * Serves the full MCP server via the v2 SDK's `createMcpHandler`, whose
+ * web-standard `fetch` face runs natively on Workers. Dual protocol eras are
+ * served from one handler: legacy 2025-era clients statelessly per request
+ * (`legacy: 'stateless'`), modern 2026-07-28 envelope clients natively.
+ * It reuses the exact same `createMcpServer()` factory as the stdio / Node
+ * HTTP entrypoints (see `mcp-server.ts`), so there is no second tool
+ * implementation to maintain.
  *
  * Credentials are resolved per request, in order:
  * 1. Gateway headers (when AUTH_MODE=gateway):
@@ -20,12 +22,11 @@
  * `tools/list` and `initialize` work without credentials; only `tools/call`
  * requires them.
  */
-import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/server";
+import { createMcpHandler, type McpHttpHandler } from "@modelcontextprotocol/server";
 import {
-  createMcpServer,
+  makeMcpServerFactory,
   resolveGatewayCredentials,
   buildCredentials,
-  type NinjaOneCredentials,
 } from "./mcp-server.js";
 
 export interface Env {
@@ -57,6 +58,39 @@ function withCors(res: Response): Response {
   return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 
+/**
+ * One MCP handler per distinct Worker `env` object. In production the runtime
+ * passes the same `env` to every fetch in an isolate, so this memoizes to a
+ * single handler per isolate; the handler's factory still runs per request
+ * (stateless), exactly like the previous per-request Server + Transport
+ * wiring. Tests that pass differing env objects each get a matching handler.
+ */
+const handlers = new WeakMap<Env, McpHttpHandler>();
+
+function getMcpHandler(env: Env): McpHttpHandler {
+  let handler = handlers.get(env);
+  if (!handler) {
+    const isGatewayMode = (env.AUTH_MODE ?? "env") === "gateway";
+    handler = createMcpHandler(
+      makeMcpServerFactory({
+        gatewayMode: isGatewayMode,
+        // env mode: build credentials from Worker secrets if present.
+        // (Absent creds are fine — tools/list still works, tools/call errors.)
+        envCredentials: isGatewayMode
+          ? undefined
+          : buildCredentials(
+              env.NINJAONE_CLIENT_ID,
+              env.NINJAONE_CLIENT_SECRET,
+              env.NINJAONE_REGION
+            ).creds,
+      }),
+      { legacy: "stateless" }
+    );
+    handlers.set(env, handler);
+  }
+  return handler;
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -74,9 +108,8 @@ export default {
     if (url.pathname === "/mcp") {
       const isGatewayMode = (env.AUTH_MODE ?? "env") === "gateway";
 
-      let credOverrides: NinjaOneCredentials | undefined;
       if (isGatewayMode) {
-        const { creds, error } = resolveGatewayCredentials(
+        const { error } = resolveGatewayCredentials(
           (name) => request.headers.get(name) ?? undefined
         );
         if (error) {
@@ -90,33 +123,12 @@ export default {
             401
           );
         }
-        credOverrides = creds;
-      } else {
-        // env mode: build credentials from Worker secrets if present.
-        // (Absent creds are fine — tools/list still works, tools/call errors.)
-        const { creds } = buildCredentials(
-          env.NINJAONE_CLIENT_ID,
-          env.NINJAONE_CLIENT_SECRET,
-          env.NINJAONE_REGION
-        );
-        credOverrides = creds;
       }
 
-      // Fresh server + transport per request (stateless).
-      const server = await createMcpServer(credOverrides);
-      const transport = new WebStandardStreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      });
-      await server.connect(transport);
-
-      try {
-        const response = await transport.handleRequest(request);
-        return withCors(response);
-      } finally {
-        await transport.close();
-        await server.close();
-      }
+      // Per-request credential binding happens inside the factory (gateway
+      // mode reads the X-Ninja-* headers from ctx.requestInfo every request).
+      const response = await getMcpHandler(env).fetch(request);
+      return withCors(response);
     }
 
     return json(


### PR DESCRIPTION
Closes #69 (pilot #2 of the MCP 2026-07-28 spec migration, alongside wyre-technology/autotask-mcp#218).

Migrates from `@modelcontextprotocol/sdk` v1 to the split v2 beta (`server`/`node` @ 2.0.0-beta.5). One shared `McpServerFactory` backs both entrypoints — stdio (`serveStdio`) and HTTP/Worker (`createMcpHandler`, `legacy: 'stateless'` default) — so 2025-era `initialize`-handshake clients keep working through the deprecation window while the 2026-07-28 envelope protocol is served natively. Hand-written JSON Schema tool definitions unchanged (valid under 2020-12); no zod introduced.

**Acceptance artifact** — `scripts/smoke-dual-era.mjs`: the same endpoint answers a legacy handshake sequence and a modern v2 client session; both list the identical 25 tools. Wire `tools/list` proven byte-equal to source definitions; gateway `X-Ninja-*` credential contract live-checked (401 without headers, correct region binding with).

Local verification: vitest 154/154, typecheck + lint clean.

**Draft until:** review + fleet-rollout decision on v2 stable (intentionally on the beta SDK as a pilot). Notable for reviewers: legacy-era POST responses are now SSE-framed (v2 shim has no `enableJsonResponse`) — spec-conforming clients and the gateway's SSE parser handle this; hand-rolled JSON-only consumers would not.