### PR TITLE
fix(security): eliminate module-level credential singleton to close cross-tenant leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## [Unreleased]
 
+### Security
+
+- **Fixed a cross-tenant credential leak in gateway mode.** Gateway mode
+  previously stored per-request vendor credentials/client on module-level
+  mutable singletons (`_clientOverride`, `_credentialOverrides` in
+  `src/utils/client.ts`), set at the top of the `CallToolRequestSchema`
+  handler and cleared in a `finally` block. Real `await` gaps between set and
+  clear (dispatch into any of the 4 domain handlers, each of which awaits
+  network I/O) meant a concurrent request from a different tenant could
+  observe another tenant's vendor client/credentials. Replaced both
+  singletons with `AsyncLocalStorage`-scoped storage (`runWithCredentials()`)
+  — each gateway request now runs inside its own isolated async context, so
+  `getCredentials()` / `getClient()` always resolve that request's own
+  credentials regardless of how requests interleave. No shared mutable state
+  remains in the gateway code path; the 4 domain handler files
+  (`devices.ts`, `organizations.ts`, `alerts.ts`, `tickets.ts`) are
+  unchanged.
+
 ### Added
 
 - **Interactive alert card via MCP Apps (SEP-1865).** A new `ninjaone_alerts_get`

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -260,15 +260,20 @@ describe("NinjaOne Client Utilities", () => {
       process.env.NINJAONE_CLIENT_SECRET = "test-secret";
       process.env.NINJAONE_REGION = "us";
 
-      const client1 = await getClient();
+      const client1 = (await getClient()) as unknown as { config: { clientId: string } };
 
       // Change credentials
       process.env.NINJAONE_CLIENT_ID = "test-id-2";
       clearClient();
 
-      const client2 = await getClient();
+      const client2 = (await getClient()) as unknown as { config: { clientId: string } };
 
+      // Identity alone (not.toBe) would pass even if getClient() ignored
+      // the changed env var and rebuilt from stale credentials — the
+      // load-bearing check is that client2 actually reflects the new value.
       expect(client1).not.toBe(client2);
+      expect(client1.config.clientId).toBe("test-id-1");
+      expect(client2.config.clientId).toBe("test-id-2");
     });
 
     // Regression: before the fix, a left-blank optional region arrived as the
@@ -300,7 +305,14 @@ describe("NinjaOne Client Utilities", () => {
       clearClient();
       const client2 = await getClient();
 
+      // Distinct object identity proves a new instance was actually built
+      // (not just returned from cache); the constructedConfigs count proves
+      // it was built twice, not that a stale value silently short-circuited
+      // the cache invalidation.
       expect(client1).not.toBe(client2);
+      expect(constructedConfigs).toHaveLength(2);
+      expect(constructedConfigs[0]).toMatchObject({ clientId: "test-id" });
+      expect(constructedConfigs[1]).toMatchObject({ clientId: "test-id" });
     });
   });
 

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -3,42 +3,31 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getCredentials, getClient, clearClient } from "../utils/client.js";
+import {
+  getCredentials,
+  getClient,
+  clearClient,
+  runWithCredentials,
+} from "../utils/client.js";
+import * as clientModule from "../utils/client.js";
+
+// The mock fn is created up front via vi.hoisted (not inline in the factory
+// below) and its implementation is (re-)applied in beforeEach rather than
+// baked into the factory call. client.ts imports the SDK statically now (see
+// the comment there), which means this module is evaluated once, up front,
+// before any test's beforeEach hooks run — with the project's mockReset:true
+// config, an implementation set only inside the vi.mock() factory gets wiped
+// by the automatic pre-test reset before the very first test ever sees it.
+// Re-applying it in beforeEach keeps it correct no matter how it interacts
+// with the auto-reset.
+const { NinjaOneClientMock, constructedConfigs } = vi.hoisted(() => ({
+  NinjaOneClientMock: vi.fn(),
+  constructedConfigs: [] as { clientId: string; clientSecret: string; baseUrl: string }[],
+}));
 
 // Mock the node-ninjaone library
 vi.mock("@wyre-technology/node-ninjaone", () => ({
-  NinjaOneClient: vi.fn().mockImplementation(function (config) { return ({
-    config,
-    devices: {
-      list: vi.fn(),
-      get: vi.fn(),
-      reboot: vi.fn(),
-      getServices: vi.fn(),
-      getAlerts: vi.fn(),
-      getActivities: vi.fn(),
-    },
-    organizations: {
-      list: vi.fn(),
-      get: vi.fn(),
-      create: vi.fn(),
-      getLocations: vi.fn(),
-      getDevices: vi.fn(),
-    },
-    alerts: {
-      list: vi.fn(),
-      reset: vi.fn(),
-      resetAll: vi.fn(),
-      getSummary: vi.fn(),
-    },
-    tickets: {
-      list: vi.fn(),
-      get: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      addComment: vi.fn(),
-      getComments: vi.fn(),
-    },
-  }) }),
+  NinjaOneClient: NinjaOneClientMock,
 }));
 
 describe("NinjaOne Client Utilities", () => {
@@ -48,6 +37,47 @@ describe("NinjaOne Client Utilities", () => {
     // Reset environment variables before each test
     process.env = { ...originalEnv };
     clearClient();
+    constructedConfigs.length = 0;
+    NinjaOneClientMock.mockReset();
+    NinjaOneClientMock.mockImplementation(function (config: {
+      clientId: string;
+      clientSecret: string;
+      baseUrl: string;
+    }) {
+      constructedConfigs.push(config);
+      return {
+        config,
+        devices: {
+          list: vi.fn(),
+          get: vi.fn(),
+          reboot: vi.fn(),
+          getServices: vi.fn(),
+          getAlerts: vi.fn(),
+          getActivities: vi.fn(),
+        },
+        organizations: {
+          list: vi.fn(),
+          get: vi.fn(),
+          create: vi.fn(),
+          getLocations: vi.fn(),
+          getDevices: vi.fn(),
+        },
+        alerts: {
+          list: vi.fn(),
+          reset: vi.fn(),
+          resetAll: vi.fn(),
+          getSummary: vi.fn(),
+        },
+        tickets: {
+          list: vi.fn(),
+          get: vi.fn(),
+          create: vi.fn(),
+          update: vi.fn(),
+          addComment: vi.fn(),
+          getComments: vi.fn(),
+        },
+      };
+    });
   });
 
   afterEach(() => {
@@ -271,6 +301,85 @@ describe("NinjaOne Client Utilities", () => {
       const client2 = await getClient();
 
       expect(client1).not.toBe(client2);
+    });
+  });
+
+  describe("gateway credential isolation", () => {
+    it("no longer exports the deleted module-level override functions", () => {
+      const exported = clientModule as unknown as Record<string, unknown>;
+      expect(exported.setClientOverride).toBeUndefined();
+      expect(exported.clearClientOverride).toBeUndefined();
+      expect(exported.setCredentialOverrides).toBeUndefined();
+      expect(exported.clearCredentialOverrides).toBeUndefined();
+    });
+
+    it("isolates concurrent runWithCredentials() calls even when they interleave", async () => {
+      const credsA = {
+        clientId: "tenant-a-id",
+        clientSecret: "tenant-a-secret",
+        region: "us" as const,
+        baseUrl: "https://app.ninjarmm.com",
+      };
+      const credsB = {
+        clientId: "tenant-b-id",
+        clientSecret: "tenant-b-secret",
+        region: "eu" as const,
+        baseUrl: "https://eu.ninjarmm.com",
+      };
+
+      const runA = runWithCredentials(credsA, async () => {
+        // Artificial delay forces real interleaving with runB below, rather
+        // than the two calls simply resolving in program order.
+        await new Promise((r) => setTimeout(r, 10));
+        return { creds: getCredentials(), client: await getClient() };
+      });
+
+      const runB = runWithCredentials(credsB, async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        return { creds: getCredentials(), client: await getClient() };
+      });
+
+      const [resultA, resultB] = await Promise.all([runA, runB]);
+
+      // Each frame must resolve its own credentials, never the other's.
+      expect(resultA.creds).toEqual(credsA);
+      expect(resultB.creds).toEqual(credsB);
+
+      const configA = constructedConfigs.find((c) => c.clientId === credsA.clientId);
+      const configB = constructedConfigs.find((c) => c.clientId === credsB.clientId);
+
+      expect(configA).toMatchObject({
+        clientId: credsA.clientId,
+        clientSecret: credsA.clientSecret,
+      });
+      expect(configB).toMatchObject({
+        clientId: credsB.clientId,
+        clientSecret: credsB.clientSecret,
+      });
+      expect(resultA.client).not.toBe(resultB.client);
+    });
+
+    it("does not populate the shared single-tenant client cache for gateway-scoped requests", async () => {
+      // Prime a genuine single-tenant (env-mode) client + cache.
+      process.env.NINJAONE_CLIENT_ID = "env-id";
+      process.env.NINJAONE_CLIENT_SECRET = "env-secret";
+      process.env.NINJAONE_REGION = "us";
+      const envClient = await getClient();
+
+      const gatewayCreds = {
+        clientId: "gateway-id",
+        clientSecret: "gateway-secret",
+        region: "us" as const,
+        baseUrl: "https://app.ninjarmm.com",
+      };
+      const gatewayClient = await runWithCredentials(gatewayCreds, () => getClient());
+
+      expect(gatewayClient).not.toBe(envClient);
+
+      // A later non-scoped call must still resolve the original env-mode
+      // cached client — the gateway-scoped call above must not have clobbered it.
+      const envClientAgain = await getClient();
+      expect(envClientAgain).toBe(envClient);
     });
   });
 });

--- a/src/__tests__/flattened-navigation.test.ts
+++ b/src/__tests__/flattened-navigation.test.ts
@@ -15,10 +15,7 @@ vi.mock("../utils/client.js", () => ({
     baseUrl: "https://app.ninjarmm.com",
   }),
   createClientDirect: vi.fn().mockResolvedValue({}),
-  setClientOverride: vi.fn(),
-  clearClientOverride: vi.fn(),
-  setCredentialOverrides: vi.fn(),
-  clearCredentialOverrides: vi.fn(),
+  runWithCredentials: vi.fn((_creds, fn) => fn()),
 }));
 
 // Mock domain handlers using vi.hoisted

--- a/src/__tests__/gateway-concurrency.test.ts
+++ b/src/__tests__/gateway-concurrency.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression test for the cross-tenant credential leak in gateway mode.
+ *
+ * Before the fix, gateway mode set request-scoped credentials on module-level
+ * mutable singletons (`_clientOverride` / `_credentialOverrides` in
+ * src/utils/client.ts) that were cleared in a `finally` block after each tool
+ * call — but real await gaps between "set" and "clear" (dispatch into a
+ * domain handler that itself awaits network I/O) meant a concurrent request
+ * from a different tenant could read a tenant it doesn't belong to.
+ *
+ * This test drives the real request path — `worker.fetch()`, the same
+ * `createMcpServer()` factory used by both the Cloudflare Workers entrypoint
+ * and the Node HTTP transport in index.ts — with two concurrent `tools/call`
+ * requests carrying different `X-Ninja-Client-*` credentials, one of which
+ * has its mocked vendor API call artificially delayed so it is still
+ * in-flight while the other request's headers are being resolved. Each
+ * response must reflect only its own request's credentials.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import worker, { type Env } from "../worker.js";
+
+interface CapturedConfig {
+  clientId: string;
+  clientSecret: string;
+}
+
+// The mock fn is created via vi.hoisted and its implementation (re-)applied
+// in beforeEach rather than baked into the vi.mock() factory. client.ts
+// imports the SDK statically, so this module evaluates once, up front,
+// before any beforeEach hooks run — with the project's mockReset:true
+// config, a factory-only implementation would get wiped by the automatic
+// pre-test reset before this test ever saw it.
+const { NinjaOneClientMock } = vi.hoisted(() => ({
+  NinjaOneClientMock: vi.fn(),
+}));
+
+vi.mock("@wyre-technology/node-ninjaone", () => ({
+  NinjaOneClient: NinjaOneClientMock,
+}));
+
+beforeEach(() => {
+  NinjaOneClientMock.mockReset();
+  NinjaOneClientMock.mockImplementation(function (config: CapturedConfig) {
+    return {
+      organizations: {
+        list: vi.fn().mockImplementation(async () => {
+          // Tenant A's vendor call is deliberately slow, so it is guaranteed
+          // to still be in-flight while tenant B's concurrent request is
+          // resolved end-to-end.
+          if (config.clientId === "tenant-a-id") {
+            await new Promise((r) => setTimeout(r, 40));
+          }
+          return [{ id: 1, name: `org-for-${config.clientId}` }];
+        }),
+      },
+    };
+  });
+});
+
+const MCP_HEADERS = {
+  Accept: "application/json, text/event-stream",
+  "Content-Type": "application/json",
+};
+
+function orgsListRequest(id: number) {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "tools/call",
+    params: { name: "ninjaone_organizations_list", arguments: {} },
+  };
+}
+
+async function mcp(
+  body: unknown,
+  headers: Record<string, string>,
+  env: Env = { AUTH_MODE: "gateway" }
+): Promise<Response> {
+  return worker.fetch(
+    new Request("http://worker.local/mcp", {
+      method: "POST",
+      headers: { ...MCP_HEADERS, ...headers },
+      body: JSON.stringify(body),
+    }),
+    env
+  );
+}
+
+describe("Gateway mode: cross-tenant credential isolation under real concurrency", () => {
+  it("resolves each concurrent tenant's own credentials, never swapped", async () => {
+    const [resA, resB] = await Promise.all([
+      mcp(orgsListRequest(1), {
+        "x-ninja-client-id": "tenant-a-id",
+        "x-ninja-client-secret": "tenant-a-secret",
+      }),
+      mcp(orgsListRequest(2), {
+        "x-ninja-client-id": "tenant-b-id",
+        "x-ninja-client-secret": "tenant-b-secret",
+      }),
+    ]);
+
+    expect(resA.status).toBe(200);
+    expect(resB.status).toBe(200);
+
+    const bodyA = (await resA.json()) as {
+      result?: { content?: { text?: string }[] };
+    };
+    const bodyB = (await resB.json()) as {
+      result?: { content?: { text?: string }[] };
+    };
+
+    const textA = bodyA.result?.content?.[0]?.text ?? "";
+    const textB = bodyB.result?.content?.[0]?.text ?? "";
+
+    // Tenant B's fast response lands first, while tenant A's is still
+    // in-flight. Each must reflect only its own tenant's data.
+    expect(textB).toContain("org-for-tenant-b-id");
+    expect(textB).not.toContain("tenant-a-id");
+
+    expect(textA).toContain("org-for-tenant-a-id");
+    expect(textA).not.toContain("tenant-b-id");
+  });
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -19,14 +19,15 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { getDomainHandler, getAvailableDomains } from "./domains/index.js";
-import { isDomainName, isValidRegion, getBaseUrlForRegion } from "./utils/types.js";
+import {
+  isDomainName,
+  isValidRegion,
+  getBaseUrlForRegion,
+  type CallToolResult,
+} from "./utils/types.js";
 import {
   getCredentials,
-  createClientDirect,
-  setClientOverride,
-  clearClientOverride,
-  setCredentialOverrides,
-  clearCredentialOverrides,
+  runWithCredentials,
   type NinjaOneCredentials,
 } from "./utils/client.js";
 import { logger } from "./utils/logger.js";
@@ -223,103 +224,96 @@ export async function createMcpServer(
     const { name, arguments: args } = request.params;
     logger.info("Tool call received", { tool: name, arguments: args });
 
-    if (credentialOverrides) {
-      setCredentialOverrides(credentialOverrides);
-      const directClient = await createClientDirect(credentialOverrides);
-      setClientOverride(directClient);
-    }
+    const run = async (): Promise<CallToolResult> => {
+      try {
+        if (name === "ninjaone_navigate") {
+          const domain = (args as { domain: string }).domain;
 
-    try {
-      if (name === "ninjaone_navigate") {
-        const domain = (args as { domain: string }).domain;
+          if (!isDomainName(domain)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Invalid domain: ${domain}. Available domains: ${getAvailableDomains().join(", ")}`,
+                },
+              ],
+              isError: true,
+            };
+          }
 
-        if (!isDomainName(domain)) {
+          const handler = await getDomainHandler(domain);
+          const domainTools = handler.getTools();
+
+          const toolSummary = domainTools
+            .map((t) => `- ${t.name}: ${t.description}`)
+            .join("\n");
+
           return {
             content: [
               {
                 type: "text",
-                text: `Invalid domain: ${domain}. Available domains: ${getAvailableDomains().join(", ")}`,
+                text: `${domainDescriptions[domain]}\n\nAvailable tools:\n${toolSummary}\n\nYou can call any of these tools directly.`,
               },
             ],
-            isError: true,
           };
         }
 
-        const handler = await getDomainHandler(domain);
-        const domainTools = handler.getTools();
+        if (name === "ninjaone_status") {
+          const creds = getCredentials();
+          const credStatus = creds
+            ? `Configured (region: ${creds.region}, base URL: ${creds.baseUrl})`
+            : "NOT CONFIGURED - Please set environment variables";
 
-        const toolSummary = domainTools
-          .map((t) => `- ${t.name}: ${t.description}`)
-          .join("\n");
+          return {
+            content: [
+              {
+                type: "text",
+                text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
+              },
+            ],
+          };
+        }
+
+        const toolArgs = (args ?? {}) as Record<string, unknown>;
+
+        if (name.startsWith("ninjaone_devices_")) {
+          const handler = await getDomainHandler("devices");
+          return await handler.handleCall(name, toolArgs);
+        }
+        if (name.startsWith("ninjaone_organizations_")) {
+          const handler = await getDomainHandler("organizations");
+          return await handler.handleCall(name, toolArgs);
+        }
+        if (name.startsWith("ninjaone_alerts_")) {
+          const handler = await getDomainHandler("alerts");
+          return await handler.handleCall(name, toolArgs);
+        }
+        if (name.startsWith("ninjaone_tickets_")) {
+          const handler = await getDomainHandler("tickets");
+          return await handler.handleCall(name, toolArgs);
+        }
 
         return {
           content: [
             {
               type: "text",
-              text: `${domainDescriptions[domain]}\n\nAvailable tools:\n${toolSummary}\n\nYou can call any of these tools directly.`,
+              text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
             },
           ],
+          isError: true,
         };
-      }
-
-      if (name === "ninjaone_status") {
-        const creds = getCredentials();
-        const credStatus = creds
-          ? `Configured (region: ${creds.region}, base URL: ${creds.baseUrl})`
-          : "NOT CONFIGURED - Please set environment variables";
-
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const stack = error instanceof Error ? error.stack : undefined;
+        logger.error("Tool call failed", { tool: name, error: message, stack });
         return {
-          content: [
-            {
-              type: "text",
-              text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
-            },
-          ],
+          content: [{ type: "text", text: `Error: ${message}` }],
+          isError: true,
         };
       }
+    };
 
-      const toolArgs = (args ?? {}) as Record<string, unknown>;
-
-      if (name.startsWith("ninjaone_devices_")) {
-        const handler = await getDomainHandler("devices");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_organizations_")) {
-        const handler = await getDomainHandler("organizations");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_alerts_")) {
-        const handler = await getDomainHandler("alerts");
-        return await handler.handleCall(name, toolArgs);
-      }
-      if (name.startsWith("ninjaone_tickets_")) {
-        const handler = await getDomainHandler("tickets");
-        return await handler.handleCall(name, toolArgs);
-      }
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
-          },
-        ],
-        isError: true,
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      const stack = error instanceof Error ? error.stack : undefined;
-      logger.error("Tool call failed", { tool: name, error: message, stack });
-      return {
-        content: [{ type: "text", text: `Error: ${message}` }],
-        isError: true,
-      };
-    } finally {
-      if (credentialOverrides) {
-        clearClientOverride();
-        clearCredentialOverrides();
-      }
-    }
+    return credentialOverrides ? runWithCredentials(credentialOverrides, run) : run();
   });
 
   return server;

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -1,11 +1,21 @@
 /**
- * Lazy-loaded NinjaOne client
+ * Lazy-initialized NinjaOne client
  *
- * This module provides lazy initialization of the NinjaOne client
- * to avoid loading the entire library upfront.
+ * This module defers *constructing* a NinjaOneClient instance until the
+ * first `getClient()` call (single-tenant env mode caches it thereafter;
+ * gateway mode constructs one per request via `createClientDirect()`).
+ *
+ * The SDK is imported statically (not via a dynamic `await import()`):
+ * under real concurrent load, a dynamic import of a module that is also
+ * `vi.mock()`-intercepted can race and resolve to the real, un-mocked
+ * module for one of the concurrent calls — the same flake class hit by
+ * ncentral-mcp and connectwise-automate-mcp this week (symptom there:
+ * "only 1 of N expected mock instances shows up"; here, both requests
+ * silently fell through to the real SDK and made live HTTP calls). A
+ * static import always resolves through the mocked binding.
  */
-
-import type { NinjaOneClient } from "@wyre-technology/node-ninjaone";
+import { NinjaOneClient } from "@wyre-technology/node-ninjaone";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { isValidRegion, getBaseUrlForRegion, type NinjaOneRegion } from "./types.js";
 import { logger } from "./logger.js";
 
@@ -26,11 +36,17 @@ const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
 let _client: NinjaOneClient | null = null;
 let _credentials: NinjaOneCredentials | null = null;
 
-/** Per-request client override — takes priority over the cached singleton */
-let _clientOverride: NinjaOneClient | null = null;
+/**
+ * Request-scoped credentials for gateway mode. The HTTP/Worker entrypoint wraps
+ * each request's handling in runWithCredentials(creds, fn); getCredentials() reads
+ * it via .getStore(). Concurrent requests each get their own isolated store frame —
+ * there is no shared mutable state left to race on.
+ */
+const credentialStore = new AsyncLocalStorage<NinjaOneCredentials>();
 
-/** Per-request credential override — takes priority over env vars */
-let _credentialOverrides: NinjaOneCredentials | null = null;
+export function runWithCredentials<T>(creds: NinjaOneCredentials, fn: () => T): T {
+  return credentialStore.run(creds, fn);
+}
 
 /**
  * Create a fresh NinjaOneClient directly from credentials,
@@ -39,7 +55,6 @@ let _credentialOverrides: NinjaOneCredentials | null = null;
 export async function createClientDirect(
   creds: NinjaOneCredentials
 ): Promise<NinjaOneClient> {
-  const { NinjaOneClient } = await import("@wyre-technology/node-ninjaone");
   return new NinjaOneClient({
     clientId: creds.clientId,
     clientSecret: creds.clientSecret,
@@ -48,41 +63,12 @@ export async function createClientDirect(
 }
 
 /**
- * Set a request-scoped client override.
- * While set, getClient() returns this instance instead of the cached one.
- */
-export function setClientOverride(client: NinjaOneClient): void {
-  _clientOverride = client;
-}
-
-/**
- * Clear the request-scoped client override.
- */
-export function clearClientOverride(): void {
-  _clientOverride = null;
-}
-
-/**
- * Set request-scoped credential overrides.
- * While set, getCredentials() returns these instead of reading env vars.
- */
-export function setCredentialOverrides(creds: NinjaOneCredentials): void {
-  _credentialOverrides = creds;
-}
-
-/**
- * Clear request-scoped credential overrides.
- */
-export function clearCredentialOverrides(): void {
-  _credentialOverrides = null;
-}
-
-/**
- * Get credentials from environment variables (or per-request overrides)
+ * Get credentials from environment variables (or the request-scoped ALS override)
  */
 export function getCredentials(): NinjaOneCredentials | null {
-  if (_credentialOverrides) {
-    return _credentialOverrides;
+  const scoped = credentialStore.getStore();
+  if (scoped) {
+    return scoped;
   }
 
   const clientId = process.env.NINJAONE_CLIENT_ID;
@@ -120,16 +106,20 @@ export function getCredentials(): NinjaOneCredentials | null {
  * Get or create the NinjaOne client (lazy initialization)
  */
 export async function getClient(): Promise<NinjaOneClient> {
-  if (_clientOverride) {
-    return _clientOverride;
-  }
-
   const creds = getCredentials();
 
   if (!creds) {
     throw new Error(
       "No API credentials provided. Please configure NINJAONE_CLIENT_ID, NINJAONE_CLIENT_SECRET, and optionally NINJAONE_REGION (us, eu, oc, ca, us2, fed) environment variables."
     );
+  }
+
+  // Gateway (request-scoped) credentials never populate the shared _client /
+  // _credentials cache below — doing so would reintroduce a milder version of
+  // the same cross-tenant bug for subsequent non-scoped (env-mode) calls.
+  const scoped = credentialStore.getStore();
+  if (scoped) {
+    return createClientDirect(scoped);
   }
 
   // If credentials changed, invalidate the cached client
@@ -146,7 +136,6 @@ export async function getClient(): Promise<NinjaOneClient> {
 
   if (!_client) {
     try {
-      const { NinjaOneClient } = await import("@wyre-technology/node-ninjaone");
       logger.info("Creating NinjaOne client", { region: creds.region, baseUrl: creds.baseUrl });
       _client = new NinjaOneClient({
         clientId: creds.clientId,


### PR DESCRIPTION
## Summary
- Gateway mode used module-level mutable singletons (`_clientOverride`, `_credentialOverrides` in src/utils/client.ts), set/cleared per-request inside the CallToolRequestSchema handler in mcp-server.ts with real await gaps in between (dispatch into any of 4 domain handler files, each of which awaits network I/O) — concurrent requests from different tenants could observe each other's vendor API client/credentials. Same bug class as the process.env-mutation leak fixed elsewhere this week, different mechanism (module-level `let` instead of process.env).
- Fix: removed both singletons and their setter/clearer functions entirely; replaced with AsyncLocalStorage-scoped credential storage (`runWithCredentials()` / `credentialStore.getStore()`). Each gateway request now runs inside its own isolated async context; getCredentials()/getClient() transparently resolve that request's own credentials no matter how requests interleave. No shared mutable state remains anywhere in the gateway code path.
- Parameter-threading (used in kaseya-bms-mcp/connectwise-automate-mcp) was considered but not used here: this repo has 4 separate domain handler files (devices/organizations/alerts/tickets) each independently calling the shared client getter, so ALS is the lower-blast-radius fix — zero domain handler files needed signature changes. No Cloudflare Worker constraint blocks ALS (nodejs_compat is enabled), matching the pattern already used in ncentral-mcp for this same call-chain shape.
- Also switched `src/utils/client.ts`'s NinjaOne SDK import from a dynamic `await import()` to a static top-level import. Under real concurrent load, the dynamic import raced with Vitest's `vi.mock()` interception and resolved to the real, un-mocked SDK for one of the two concurrent calls — the exact flake class already hit and fixed this way in ncentral-mcp and connectwise-automate-mcp this week. Node's real dynamic `import()` is cache-deduped so this is a test-only concern, not a production behavior change.

**Provenance, not a regression:** the `_clientOverride`/`_credentialOverrides` singleton has been present since the 2026-04-13 fix (commit `1e9f5c29`, "isolate per-request credentials in gateway mode") that introduced per-request credential isolation for this repo — `src/utils/client.ts` has had no other substantive change since (the only intervening commit, `62d74bc`, was an unrelated `NINJAONE_REGION` config-placeholder fix). This isn't new breakage; the singleton mechanism the 04-13 fix chose *is* the race, and has been since it shipped. This also supersedes an earlier 2026-07-22 fleet-wide audit verdict that read this repo as SAFE — that pass specifically checked for `process.env` mutation (which this repo never did), but missed that the singleton pattern carries the identical cross-tenant race via a different shared global. Found in a follow-up audit pass this week that specifically checked for both variants.

## Test plan
- [x] New concurrent-request isolation test (`src/__tests__/gateway-concurrency.test.ts`) driving the real `worker.fetch()` request path with two concurrent `tools/call` requests carrying different tenant credentials — one tenant's mocked vendor API call is artificially delayed so it's still in-flight while the other tenant's request resolves, and each response is asserted to reflect only its own tenant's data
- [x] New `runWithCredentials()` isolation test in `src/__tests__/client.test.ts` forcing genuine interleaving via `Promise.all` + artificial delay before each frame reads `getCredentials()`/`getClient()` — this test fails against the pre-fix singleton implementation and passes against the fix, proving the race is structurally eliminated (no shared state left to race on), not just narrowed
- [x] Regression guard confirming `setClientOverride`/`clearClientOverride`/`setCredentialOverrides`/`clearCredentialOverrides` are no longer exported
- [x] `flattened-navigation.test.ts` updated to drop mocks of the deleted exports
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Full test suite green: 158/158 passing (verified across 6 consecutive runs for flakiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
