### PR TITLE
fix(security): enforce gateway S2S verification (gateway#377 parity)

### DIFF
--- a/src/__tests__/s2s-verify.test.ts
+++ b/src/__tests__/s2s-verify.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifyS2sHeader } from "../s2s-verify.js";
+
+/**
+ * Mirrors conduit's own gateway-side derivation + minting (src/proxy/s2s.ts
+ * deriveRecipientSubkey / s2sHeaders) so this test can simulate the real
+ * deploy-time flow without needing a live conduit-prod deploy: the gateway
+ * derives one subkey per vendor slug from a master secret, and mints a
+ * header keyed by that derived subkey for a specific outbound request.
+ */
+function deriveRecipientSubkey(masterSecret: string, slug: string): string {
+  return createHmac("sha256", masterSecret).update(`s2s-recipient:${slug}`).digest("hex");
+}
+
+function mintHeader(secret: string, unixSeconds: number): string {
+  const message = `t=${unixSeconds}`;
+  const hex = createHmac("sha256", secret).update(message).digest("hex");
+  return `${message},v1=${hex}`;
+}
+
+describe("verifyS2sHeader", () => {
+  const MASTER = "test-master-secret-do-not-use-in-prod";
+  const ninjaoneSubkey = deriveRecipientSubkey(MASTER, "ninjaone");
+  const liongardSubkey = deriveRecipientSubkey(MASTER, "liongard");
+  const now = Math.floor(Date.now() / 1000);
+
+  it("accepts a header minted with this vendor's own derived subkey", () => {
+    const header = mintHeader(ninjaoneSubkey, now);
+    expect(verifyS2sHeader(header, ninjaoneSubkey)).toBe(true);
+  });
+
+  it("REJECTS a header minted for a different vendor's derived subkey (recipient-binding proof)", () => {
+    // A header a compromised sibling sidecar could produce for itself must
+    // NOT verify here — this is the actual property Finding B's rollout
+    // needs to deliver, not just "some verify function exists."
+    const headerMintedForLiongard = mintHeader(liongardSubkey, now);
+    expect(verifyS2sHeader(headerMintedForLiongard, ninjaoneSubkey)).toBe(false);
+  });
+
+  it("rejects a stale timestamp outside the skew window", () => {
+    const staleHeader = mintHeader(ninjaoneSubkey, now - 301);
+    expect(verifyS2sHeader(staleHeader, ninjaoneSubkey)).toBe(false);
+  });
+
+  it("rejects a future timestamp outside the skew window", () => {
+    const futureHeader = mintHeader(ninjaoneSubkey, now + 301);
+    expect(verifyS2sHeader(futureHeader, ninjaoneSubkey)).toBe(false);
+  });
+
+  it("accepts a timestamp at the edge of the skew window", () => {
+    const edgeHeader = mintHeader(ninjaoneSubkey, now - 300);
+    expect(verifyS2sHeader(edgeHeader, ninjaoneSubkey)).toBe(true);
+  });
+
+  it("rejects a malformed header value", () => {
+    expect(verifyS2sHeader("not-a-valid-header", ninjaoneSubkey)).toBe(false);
+    expect(verifyS2sHeader("t=abc,v1=zz", ninjaoneSubkey)).toBe(false);
+  });
+
+  it("rejects a missing header", () => {
+    expect(verifyS2sHeader(undefined, ninjaoneSubkey)).toBe(false);
+  });
+
+  it("rejects when the secret is empty (dark-by-default guarantee)", () => {
+    const header = mintHeader(ninjaoneSubkey, now);
+    expect(verifyS2sHeader(header, "")).toBe(false);
+  });
+
+  it("rejects a tampered signature", () => {
+    const header = mintHeader(ninjaoneSubkey, now);
+    const tampered = header.slice(0, -1) + (header.endsWith("0") ? "1" : "0");
+    expect(verifyS2sHeader(tampered, ninjaoneSubkey)).toBe(false);
+  });
+});

--- a/src/__tests__/s2s-verify.test.ts
+++ b/src/__tests__/s2s-verify.test.ts
@@ -23,9 +23,9 @@ describe("verifyS2sHeader", () => {
   const MASTER = "test-master-secret-do-not-use-in-prod";
   const ninjaoneSubkey = deriveRecipientSubkey(MASTER, "ninjaone");
   const liongardSubkey = deriveRecipientSubkey(MASTER, "liongard");
-  const now = Math.floor(Date.now() / 1000);
 
   it("accepts a header minted with this vendor's own derived subkey", () => {
+    const now = Math.floor(Date.now() / 1000);
     const header = mintHeader(ninjaoneSubkey, now);
     expect(verifyS2sHeader(header, ninjaoneSubkey)).toBe(true);
   });
@@ -34,21 +34,25 @@ describe("verifyS2sHeader", () => {
     // A header a compromised sibling sidecar could produce for itself must
     // NOT verify here — this is the actual property Finding B's rollout
     // needs to deliver, not just "some verify function exists."
+    const now = Math.floor(Date.now() / 1000);
     const headerMintedForLiongard = mintHeader(liongardSubkey, now);
     expect(verifyS2sHeader(headerMintedForLiongard, ninjaoneSubkey)).toBe(false);
   });
 
   it("rejects a stale timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     const staleHeader = mintHeader(ninjaoneSubkey, now - 301);
     expect(verifyS2sHeader(staleHeader, ninjaoneSubkey)).toBe(false);
   });
 
   it("rejects a future timestamp outside the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     const futureHeader = mintHeader(ninjaoneSubkey, now + 301);
     expect(verifyS2sHeader(futureHeader, ninjaoneSubkey)).toBe(false);
   });
 
   it("accepts a timestamp at the edge of the skew window", () => {
+    const now = Math.floor(Date.now() / 1000);
     const edgeHeader = mintHeader(ninjaoneSubkey, now - 300);
     expect(verifyS2sHeader(edgeHeader, ninjaoneSubkey)).toBe(true);
   });
@@ -63,11 +67,13 @@ describe("verifyS2sHeader", () => {
   });
 
   it("rejects when the secret is empty (dark-by-default guarantee)", () => {
+    const now = Math.floor(Date.now() / 1000);
     const header = mintHeader(ninjaoneSubkey, now);
     expect(verifyS2sHeader(header, "")).toBe(false);
   });
 
   it("rejects a tampered signature", () => {
+    const now = Math.floor(Date.now() / 1000);
     const header = mintHeader(ninjaoneSubkey, now);
     const tampered = header.slice(0, -1) + (header.endsWith("0") ? "1" : "0");
     expect(verifyS2sHeader(tampered, ninjaoneSubkey)).toBe(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,13 @@ import {
   resolveGatewayCredentials,
 } from "./mcp-server.js";
 import { logger } from "./utils/logger.js";
+import { verifyS2sHeader, S2S_HEADER } from "./s2s-verify.js";
+
+// Conduit service-to-service auth (gateway#377 parity). Non-empty =
+// enforce X-Gateway-S2S on every /mcp request; empty = disabled, behavior
+// exactly as before (dark-by-default until the gateway provisions this
+// container's derived subkey). See src/s2s-verify.ts.
+const S2S_SECRET = process.env.CONDUIT_S2S_SECRET || "";
 
 /**
  * Start the server with stdio transport (default).
@@ -89,6 +96,19 @@ async function startHttpTransport(): Promise<void> {
 
     // MCP endpoint
     if (url.pathname === "/mcp") {
+      // Conduit service-to-service auth (gateway#377 parity): rejected
+      // BEFORE any credential extraction, mirroring every other ported
+      // wrapper (e.g. containers/sentinelone-mcp/gateway_wrapper.py).
+      if (S2S_SECRET && !verifyS2sHeader(req.headers[S2S_HEADER] as string | undefined, S2S_SECRET)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "Missing or invalid X-Gateway-S2S header: this endpoint only accepts requests signed by the gateway.",
+          })
+        );
+        return;
+      }
+
       if (isGatewayMode) {
         const { error } = resolveGatewayCredentials(
           (name) => req.headers[name] as string | undefined

--- a/src/s2s-verify.ts
+++ b/src/s2s-verify.ts
@@ -1,0 +1,43 @@
+/**
+ * Verifies the conduit gateway's service-to-service auth header
+ * (gateway#377 parity — closes the confused-deputy gap where a compromised
+ * sibling sidecar in the shared ACA environment could otherwise impersonate
+ * the gateway to this container).
+ *
+ * This is a near-verbatim port of conduit's `verifyS2sHeader`
+ * (src/proxy/s2s.ts) — intentionally unchanged logic, ported once and kept
+ * in sync. `secret` is treated as an opaque value: since gateway#377
+ * Finding B, the gateway derives a per-vendor subkey from its master
+ * secret and this container is provisioned (via CONDUIT_S2S_SECRET) with
+ * only its own derived value, never the raw master — a sibling sidecar
+ * holds a DIFFERENT derived value and cannot forge a header that verifies
+ * here. This function doesn't need to know that; it just checks whatever
+ * secret it's handed.
+ *
+ * Empty secret => always returns false. The caller is expected to treat an
+ * empty CONDUIT_S2S_SECRET as "S2S enforcement disabled" (dark-by-default,
+ * matches the dormant/pre-provisioning state) rather than calling this at
+ * all — see the enforcement check in index.ts.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Request header carrying the S2S proof. Node lowercases incoming header names. */
+export const S2S_HEADER = "x-gateway-s2s";
+
+const HEADER_VALUE_RE = /^t=(\d{1,15}),v1=([0-9a-f]{64})$/;
+
+export function verifyS2sHeader(
+  headerValue: string | undefined,
+  secret: string,
+  maxSkewSeconds = 300
+): boolean {
+  if (!secret || !headerValue) return false;
+  const match = HEADER_VALUE_RE.exec(headerValue);
+  if (!match) return false;
+  const t = Number(match[1]);
+  if (!Number.isSafeInteger(t)) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - t) > maxSkewSeconds) return false;
+  const expected = createHmac("sha256", secret).update(`t=${t}`).digest();
+  const provided = Buffer.from(match[2], "hex");
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}


### PR DESCRIPTION
## Summary

PILOT PR (2 of ~47, sibling to liongard-mcp#60) for the fleet-wide confused-deputy rollout following conduit gateway#377 Finding B (conduit#1182 merged). **Do not merge without Walter + boss review — auth surface, heightened-review-and-narrate tier.**

Same shape as liongard-mcp#60 (same `s2s-verify.ts`), adapted for this repo's different HTTP serving layer (`createMcpHandler`/`toNodeHandler`, dual `/health` + `/healthz`) — the insertion point (top of the `/mcp` route, before credential resolution) is unaffected by that difference.

- New `src/s2s-verify.ts`: same near-verbatim port of conduit's `verifyS2sHeader`.
- `index.ts`: enforces before `resolveGatewayCredentials`. Empty/unset `CONDUIT_S2S_SECRET` = disabled, dark-by-default.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] New unit tests (9): same coverage as liongard-mcp#60, including the cross-vendor rejection proof
- [x] Full existing suite: **166/167 passing** — 1 pre-existing failure (`gateway-concurrency.test.ts`, an unrelated SSE-parsing `SyntaxError`), confirmed via `git stash` bisection to fail identically on clean `main` before this change (not introduced by this PR)
- [x] `npm run build` — clean
- [x] **Live end-to-end smoke test** against the actual running server: no header → 401; header minted for a different vendor's derived subkey → 401; header minted for this vendor's own subkey → passes S2S, falls through to the next auth layer; both `/health` and `/healthz` still exempt
- [ ] Named pair-review (Walter + boss) — auth machinery, do not merge autonomously

## Separately flagged (not fixed here — scope discipline)
- This repo has no `ci.yml` (sibling repos like `liongard-mcp` do) — nothing runs `npm test` on PRs/pushes, which is why the pre-existing failure above has never surfaced. Flagging to boss as its own item.
- `src/__tests__/http-transport.test.ts` hand-replicates the HTTP routing logic instead of importing the real server code, and that replica is already stale relative to the actual `index.ts` (different auth-check shape). Pre-existing gap, noted while grounding this port.

Generated with Claude Code