### PR TITLE
fix(ci): bump mcp-assert reusable-workflow pin to pick up the 403 fix

### DIFF
--- a/.github/workflows/mcp-assert.yml
+++ b/.github/workflows/mcp-assert.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   assert:
-    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0  # main
+    uses: wyre-technology/.github/.github/workflows/mcp-assert.yml@7542c27000cf8d213c4910b4f397637b105a718b  # main
     with:
       entry: dist/index.js
       canary-tool: ninjaone_devices_list


### PR DESCRIPTION
Bumps the pinned wyre-technology/.github mcp-assert.yml reference from 198605d0 (2026-06-15) to 7542c2700 (current main), picking up commit 5c03d4ca (2026-07-28) which fixed the fleet-wide anonymous-curl 403 against blackwell-systems/mcp-assert's releases/latest endpoint (was causing intermittent assert-job failures fleet-wide). Verified via liongard-mcp#62 — identical change, CI confirmed green post-fix. Mechanical pin bump only, no other changes.