### PR TITLE
fix(ci): wire GHPKG_READ_TOKEN registries block into dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,25 @@
 # PRODUCTION-dependency MAJOR bumps land as individual PRs for human review,
 # since those can carry behavioural breaking changes a green test suite misses.
 version: 2
+
+# @wyre-technology/* packages are hosted on GitHub Packages (npm.pkg.github.com),
+# which has no anonymous read. Without this, Dependabot's own version-resolution
+# job for the root npm group (the one that touches this repo's own
+# @wyre-technology/node-<vendor> dependency) fails with
+# private_source_authentication_failure -- it can update every OTHER dependency
+# fine, just not this one. GHPKG_READ_TOKEN is an existing org-level Dependabot
+# secret (created 2026-06-05); this just wires it in. See task_1783631373373.
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.GHPKG_READ_TOKEN}}
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    registries:
+      - npm-github
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
- Dependabot's own version-resolution job for this repo's `@wyre-technology/node-*` private dependency has been failing with `private_source_authentication_failure` against `npm.pkg.github.com` -- Dependabot can update every other dependency fine, just not this one.
- Root cause: this repo's `.github/dependabot.yml` is missing the `registries:` block that wires in `GHPKG_READ_TOKEN` (an existing org-level Dependabot secret, created 2026-06-05 -- not a missing/expired credential, just not referenced here).
- Fix: adds the identical 7-line `registries:` block + `registries: [npm-github]` reference already present and working in liongard-mcp/knowbe4-mcp/pax8-mcp. One of a 24-repo batch fixing the same drift fleet-wide (task_1783631373373).
- No code/test impact -- Dependabot-config-only change, real CI/Release/build unaffected.

🤖 Generated with forge (cortextOS agent)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/ninjaone-mcp/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->