### PR TITLE
ci(deps): ignore typescript major-version bumps in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,15 @@ updates:
         update-types: ["minor", "patch"]
     # Production MAJORS are intentionally NOT grouped → individual PRs, held for
     # human review (never auto-merged).
+    ignore:
+      # typescript 7.x breaks this fleet's toolchain: DTS emit (tsup/rollup-plugin-dts
+      # TS5101 baseUrl-deprecated-as-error), and typescript-eslint (still <6.1.0 as of
+      # 8.66.0, no TS7 support yet). Has broken main 3x on some repos because Dependabot
+      # has no memory of a prior manual revert and just re-proposes the same major again.
+      # Deliberate hold, not a permanent blind -- remove once typescript-eslint + the
+      # tsup/DTS toolchain support TS7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

typescript 7.x breaks this fleet's toolchain:
- DTS emit via tsup/rollup-plugin-dts throws `TS5101` ("baseUrl deprecated") as a hard error under TS 7.
- `typescript-eslint` still caps its peer range below `typescript@6.1.0` as of its latest release (8.66.0) — no TS7 support yet.

Several repos in the fleet have already had this manually fixed once (typescript pinned back down) only to have Dependabot re-propose and re-merge the exact same breaking major bump later, because Dependabot has no memory of a prior manual revert. This broke `main` on multiple repos.

## What

Adds an `ignore:` rule to `.github/dependabot.yml` (npm `updates:` entry) that blocks Dependabot from proposing `typescript` **major**-version bumps. Minor/patch typescript updates are untouched and continue to flow through the existing `dev-dependencies` group.

This is a deliberate, temporary hold — not a permanent blind. Remove once `typescript-eslint` and the tsup/DTS toolchain support TS7.

Config-only change, no application code affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/ninjaone-mcp/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->