### PR TITLE
fix(ci): bump add-to-project reusable-workflow pin

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call:
-    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@6ae1533dd72f080d81b9842c22646d254b8d5e01  # pinned (warden C-4) — bump via PR not in-place edit
+    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@c3314c1065f78adf905a815ad214c71266913771  # pinned (warden C-4) — bump via PR not in-place edit
     secrets: inherit


### PR DESCRIPTION
Bumps the SHA pin on the auto-add-to-project.yml reusable workflow call to the post-#44-fix commit (wyre-technology/.github@c3314c1065f78adf905a815ad214c71266913771), so this repo actually picks up the Dependabot-PR-secrets fix instead of still running the pre-fix pinned version. See wyre-technology/.github#44.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/ninjaone-mcp/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->