### PR TITLE
fix(auth): make OAuth scopes configurable so monitoring-only apps work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## [Unreleased]
 
+### Fixed
+
+- **A monitoring-only API app could not authenticate at all.** The server never
+  passed an explicit scope list to the SDK, so every token request fell through
+  to the SDK default of `["monitoring", "management"]` and asked for
+  `scope=monitoring management`. NinjaOne rejects a client_credentials request
+  naming a scope the app was never granted (`400 invalid_scope`) rather than
+  narrowing the grant, so an app scoped to monitoring only failed at the token
+  exchange — before any tool logic ran. Every tool call failed with
+  `Failed to acquire token: 400`, including pure reads that need nothing beyond
+  monitoring, and the only apparent workaround was to over-grant `management`.
+  Scopes are now configurable via `NINJAONE_SCOPES` (or the `X-Ninja-Scopes`
+  header in gateway mode); the default is unchanged, so existing deployments
+  behave exactly as before.
+- **Tool errors dropped the upstream response body.** The tool-call handler
+  reported only `error.message`, discarding the `NinjaOneError.response` payload
+  that the SDK had already captured. An OAuth failure therefore read as a bare
+  `Failed to acquire token: 400 Bad Request` with the one diagnostic word —
+  `invalid_scope` — thrown away. The body is now appended, and an
+  `invalid_scope` rejection additionally explains how to fix it.
+
 ### Security
 
 - **Fixed a cross-tenant credential leak in gateway mode.** Gateway mode

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Set the following environment variables:
 |----------|----------|-------------|
 | `NINJAONE_CLIENT_ID` | Yes | OAuth 2.0 Client ID |
 | `NINJAONE_CLIENT_SECRET` | Yes | OAuth 2.0 Client Secret |
-| `NINJAONE_REGION` | No | Region: `us` (default), `eu`, or `oc` |
+| `NINJAONE_REGION` | No | Region: `us` (default), `eu`, `oc`, `ca`, `us2`, or `fed` |
+| `NINJAONE_SCOPES` | No | OAuth scopes to request. Defaults to `monitoring,management`. Set this if your API app is granted a narrower set — see [OAuth scopes](#oauth-scopes) |
 
 ### NinjaOne API Regions
 
@@ -85,6 +86,9 @@ Set the following environment variables:
 | `us` | `https://app.ninjarmm.com` |
 | `eu` | `https://eu.ninjarmm.com` |
 | `oc` | `https://oc.ninjarmm.com` |
+| `ca` | `https://ca.ninjarmm.com` |
+| `us2` | `https://us2.ninjarmm.com` |
+| `fed` | `https://fed.ninjarmm.com` |
 
 ## Usage
 
@@ -227,11 +231,37 @@ NinjaOne uses OAuth 2.0 for authentication. You need to:
 
 1. Log in to your NinjaOne dashboard
 2. Go to Administration > Apps > API
-3. Create a new API application
-4. Note the Client ID and Client Secret
-5. Configure the environment variables
+3. Create a new API application (application platform: **API Services**, grant type **Client Credentials**)
+4. Grant it the scopes you need — see below
+5. Note the Client ID and Client Secret
+6. Configure the environment variables
 
 The client library handles token refresh automatically.
+
+### OAuth scopes
+
+By default the server requests `monitoring management`. Which scopes you actually
+need depends on what you use:
+
+| Scope | Needed for |
+|-------|-----------|
+| `monitoring` | All read operations — listing devices, organizations, alerts, and tickets |
+| `management` | Write operations — rebooting devices, resetting alerts, creating/updating tickets and organizations |
+| `control` | Not used by this server |
+
+**If your API app is granted fewer scopes than the default, set `NINJAONE_SCOPES`
+to match.** NinjaOne rejects a token request that asks for a scope the app was
+never granted — it returns `400 invalid_scope` rather than narrowing the grant —
+so the failure happens at the token exchange and *every* tool call fails, including
+reads. For a monitoring-only app:
+
+```bash
+export NINJAONE_SCOPES="monitoring"
+```
+
+Values may be comma- or space-separated and are case-insensitive. In gateway
+deployments the same value can be supplied per request via the `X-Ninja-Scopes`
+header.
 
 ## License
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,14 +16,15 @@
     "mcp_config": {
       "command": "node",
       "args": ["${__dirname}/dist/index.js"],
-      "env": { "NINJAONE_CLIENT_ID": "${user_config.ninjaone_client_id}", "NINJAONE_CLIENT_SECRET": "${user_config.ninjaone_client_secret}", "NINJAONE_REGION": "${user_config.ninjaone_region}", "MCP_TRANSPORT": "stdio" }
+      "env": { "NINJAONE_CLIENT_ID": "${user_config.ninjaone_client_id}", "NINJAONE_CLIENT_SECRET": "${user_config.ninjaone_client_secret}", "NINJAONE_REGION": "${user_config.ninjaone_region}", "NINJAONE_SCOPES": "${user_config.ninjaone_scopes}", "MCP_TRANSPORT": "stdio" }
     }
   },
   "tools_generated": true,
   "user_config": {
     "ninjaone_client_id": { "type": "string", "title": "NinjaOne Client ID", "description": "Your NinjaOne OAuth client ID", "sensitive": true, "required": true },
     "ninjaone_client_secret": { "type": "string", "title": "NinjaOne Client Secret", "description": "Your NinjaOne OAuth client secret", "sensitive": true, "required": true },
-    "ninjaone_region": { "type": "string", "title": "NinjaOne Region", "description": "Region: us, eu, oc, ca, us2, or fed (default: us)", "sensitive": false, "required": false }
+    "ninjaone_region": { "type": "string", "title": "NinjaOne Region", "description": "Region: us, eu, oc, ca, us2, or fed (default: us)", "sensitive": false, "required": false },
+    "ninjaone_scopes": { "type": "string", "title": "NinjaOne OAuth Scopes", "description": "Scopes to request (default: monitoring,management). Set to just 'monitoring' if your API app is not granted management, otherwise the token request fails with 400 invalid_scope.", "sensitive": false, "required": false }
   },
   "compatibility": { "platforms": ["darwin", "win32", "linux"], "runtimes": { "node": ">=18.0.0" }, "claude_desktop": ">=0.10.0" }
 }

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -22,7 +22,12 @@ import * as clientModule from "../utils/client.js";
 // with the auto-reset.
 const { NinjaOneClientMock, constructedConfigs } = vi.hoisted(() => ({
   NinjaOneClientMock: vi.fn(),
-  constructedConfigs: [] as { clientId: string; clientSecret: string; baseUrl: string }[],
+  constructedConfigs: [] as {
+    clientId: string;
+    clientSecret: string;
+    baseUrl: string;
+    scopes?: string[];
+  }[],
 }));
 
 // Mock the node-ninjaone library
@@ -43,6 +48,7 @@ describe("NinjaOne Client Utilities", () => {
       clientId: string;
       clientSecret: string;
       baseUrl: string;
+      scopes?: string[];
     }) {
       constructedConfigs.push(config);
       return {
@@ -218,6 +224,30 @@ describe("NinjaOne Client Utilities", () => {
         baseUrl: "https://eu.ninjarmm.com",
       });
     });
+
+    it("leaves scopes unset when NINJAONE_SCOPES is not configured", () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      delete process.env.NINJAONE_SCOPES;
+
+      expect(getCredentials()?.scopes).toBeUndefined();
+    });
+
+    it("reads NINJAONE_SCOPES so a monitoring-only app can be expressed", () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_SCOPES = "monitoring";
+
+      expect(getCredentials()?.scopes).toEqual(["monitoring"]);
+    });
+
+    it("ignores an unparseable NINJAONE_SCOPES rather than failing to start", () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_SCOPES = "bogus";
+
+      expect(getCredentials()?.scopes).toBeUndefined();
+    });
   });
 
   describe("getClient", () => {
@@ -253,6 +283,58 @@ describe("NinjaOne Client Utilities", () => {
       const client2 = await getClient();
 
       expect(client1).toBe(client2);
+    });
+
+    // Regression: the server never passed `scopes`, so the SDK default of
+    // ["monitoring", "management"] was always requested. An API app granted
+    // monitoring only then failed the client_credentials exchange outright
+    // (400 invalid_scope) and EVERY tool call died at the token step.
+    it("forwards configured scopes to the SDK constructor", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_SCOPES = "monitoring";
+
+      await getClient();
+
+      expect(constructedConfigs.at(-1)?.scopes).toEqual(["monitoring"]);
+    });
+
+    it("omits scopes entirely when unconfigured, preserving the SDK default", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      delete process.env.NINJAONE_SCOPES;
+
+      await getClient();
+
+      expect(constructedConfigs.at(-1)?.scopes).toBeUndefined();
+    });
+
+    it("rebuilds the cached client when only the scopes change", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_SCOPES = "monitoring";
+      const client1 = await getClient();
+
+      process.env.NINJAONE_SCOPES = "monitoring,management";
+      const client2 = await getClient();
+
+      expect(client1).not.toBe(client2);
+      expect(constructedConfigs.at(-1)?.scopes).toEqual(["monitoring", "management"]);
+    });
+
+    it("forwards gateway-supplied scopes without touching the env-mode cache", async () => {
+      const gatewayClient = (await runWithCredentials(
+        {
+          clientId: "gateway-id",
+          clientSecret: "gateway-secret",
+          region: "eu" as const,
+          baseUrl: "https://eu.ninjarmm.com",
+          scopes: ["monitoring"],
+        },
+        () => getClient()
+      )) as unknown as { config: { scopes?: string[] } };
+
+      expect(gatewayClient.config.scopes).toEqual(["monitoring"]);
     });
 
     it("should create new client when credentials change", async () => {

--- a/src/__tests__/tool-errors.test.ts
+++ b/src/__tests__/tool-errors.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for tool-call error formatting.
+ *
+ * The SDK stashes an upstream error's raw response body on
+ * `NinjaOneError.response`, but the tool-call catch block used to surface only
+ * `error.message`. For an OAuth failure that meant the operator saw a bare
+ * "Failed to acquire token: 400 Bad Request" while the one diagnostic word
+ * that explained it — `invalid_scope` — was collected and then dropped.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatToolError } from "../mcp-server.js";
+
+class FakeNinjaOneError extends Error {
+  readonly statusCode: number;
+  readonly response: unknown;
+
+  constructor(message: string, statusCode: number, response?: unknown) {
+    super(message);
+    this.name = "NinjaOneAuthenticationError";
+    this.statusCode = statusCode;
+    this.response = response;
+  }
+}
+
+describe("formatToolError", () => {
+  it("appends the upstream response body so a 400 explains itself", () => {
+    const error = new FakeNinjaOneError(
+      "Failed to acquire token: 400 Bad Request",
+      400,
+      '{"error":"invalid_scope","error_description":"Invalid scope: management"}'
+    );
+
+    const text = formatToolError(error);
+
+    expect(text).toContain("Failed to acquire token: 400 Bad Request");
+    expect(text).toContain("invalid_scope");
+  });
+
+  it("adds a scope hint when the upstream rejects the requested scopes", () => {
+    const error = new FakeNinjaOneError(
+      "Failed to acquire token: 400 Bad Request",
+      400,
+      '{"error":"invalid_scope"}'
+    );
+
+    expect(formatToolError(error)).toContain("NINJAONE_SCOPES");
+  });
+
+  it("does not add the scope hint to unrelated failures", () => {
+    const error = new FakeNinjaOneError("Device not found", 404, '{"error":"not_found"}');
+
+    expect(formatToolError(error)).not.toContain("NINJAONE_SCOPES");
+  });
+
+  it("serializes a non-string response body", () => {
+    const error = new FakeNinjaOneError("Bad request", 400, { error: "invalid_scope" });
+
+    expect(formatToolError(error)).toContain("invalid_scope");
+  });
+
+  it("falls back to the bare message when there is no response body", () => {
+    expect(formatToolError(new Error("boom"))).toBe("Error: boom");
+  });
+
+  it("handles a thrown non-Error value", () => {
+    expect(formatToolError("kaboom")).toBe("Error: kaboom");
+  });
+
+  it("does not duplicate a body already contained in the message", () => {
+    const error = new FakeNinjaOneError(
+      'Request failed: {"error":"invalid_scope"}',
+      400,
+      '{"error":"invalid_scope"}'
+    );
+
+    const text = formatToolError(error);
+    expect(text.match(/invalid_scope/g)).toHaveLength(1);
+  });
+});

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -7,6 +7,7 @@ import {
   isDomainName,
   isValidRegion,
   getBaseUrlForRegion,
+  parseScopes,
 } from "../utils/types.js";
 
 describe("Type Utilities", () => {
@@ -68,6 +69,50 @@ describe("Type Utilities", () => {
 
     it("should return correct URL for FED region", () => {
       expect(getBaseUrlForRegion("fed")).toBe("https://fed.ninjarmm.com");
+    });
+  });
+
+  describe("parseScopes", () => {
+    it("returns undefined when unset, blank, or an unresolved config placeholder", () => {
+      // undefined means "caller did not choose" — the SDK default applies.
+      expect(parseScopes(undefined)).toBeUndefined();
+      expect(parseScopes("")).toBeUndefined();
+      expect(parseScopes("   ")).toBeUndefined();
+      expect(parseScopes("${user_config.ninjaone_scopes}")).toBeUndefined();
+    });
+
+    it("parses a single scope — the monitoring-only case that used to 400", () => {
+      expect(parseScopes("monitoring")).toEqual(["monitoring"]);
+    });
+
+    it("accepts comma- or space-separated lists", () => {
+      expect(parseScopes("monitoring,management")).toEqual(["monitoring", "management"]);
+      expect(parseScopes("monitoring management")).toEqual(["monitoring", "management"]);
+      expect(parseScopes("monitoring, management control")).toEqual([
+        "monitoring",
+        "management",
+        "control",
+      ]);
+    });
+
+    it("is case- and whitespace-insensitive", () => {
+      expect(parseScopes("  MONITORING , Control ")).toEqual(["monitoring", "control"]);
+    });
+
+    it("de-duplicates repeated scopes", () => {
+      expect(parseScopes("monitoring,monitoring,management")).toEqual([
+        "monitoring",
+        "management",
+      ]);
+    });
+
+    it("drops unrecognized scopes but keeps the valid ones", () => {
+      expect(parseScopes("monitoring,bogus")).toEqual(["monitoring"]);
+    });
+
+    it("returns undefined when nothing valid remains, falling back to the default", () => {
+      expect(parseScopes("bogus")).toBeUndefined();
+      expect(parseScopes("bogus,nonsense")).toBeUndefined();
     });
   });
 });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,6 +17,7 @@ import {
   isDomainName,
   isValidRegion,
   getBaseUrlForRegion,
+  parseScopes,
   type CallToolResult,
 } from "./utils/types.js";
 import {
@@ -102,6 +103,47 @@ const statusTool: Tool = {
 };
 
 /**
+ * Render a thrown error as the text a tool call reports back.
+ *
+ * The SDK's error classes carry the upstream response body on `.response`, but
+ * only `.message` used to be surfaced — so an OAuth failure read as a bare
+ * "Failed to acquire token: 400 Bad Request" with no reason attached. The body
+ * is where `invalid_scope` lives, and that one word is the whole diagnosis.
+ */
+export function formatToolError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  const raw = (error as { response?: unknown } | null)?.response;
+  const body =
+    typeof raw === "string" ? raw : raw != null ? safeStringify(raw) : undefined;
+
+  const parts = [`Error: ${message}`];
+  if (body && !message.includes(body)) {
+    parts.push(body);
+  }
+
+  // An invalid_scope rejection is fully self-inflicted and fully fixable, so
+  // say how rather than leaving the operator to infer it from an OAuth code.
+  if (body?.includes("invalid_scope")) {
+    parts.push(
+      "The API Services app does not grant every requested OAuth scope. Set NINJAONE_SCOPES " +
+        "to the scopes it actually has (e.g. NINJAONE_SCOPES=monitoring), or grant the missing " +
+        "scope in NinjaOne under Administration > Apps > API."
+    );
+  }
+
+  return parts.join("\n");
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Build a validated NinjaOneCredentials object from raw values.
  * Returns `{ creds }` on success or `{ error }` when client id/secret are missing.
  * Shared by every transport (Node HTTP headers, Workers headers, Workers env).
@@ -109,7 +151,8 @@ const statusTool: Tool = {
 export function buildCredentials(
   clientId: string | undefined,
   clientSecret: string | undefined,
-  region: string | undefined
+  region: string | undefined,
+  scopes?: string | undefined
 ): { creds?: NinjaOneCredentials; error?: string } {
   if (!clientId || !clientSecret) {
     return {
@@ -126,6 +169,7 @@ export function buildCredentials(
       clientSecret,
       region: validRegion,
       baseUrl: getBaseUrlForRegion(validRegion),
+      scopes: parseScopes(scopes ?? process.env.NINJAONE_SCOPES),
     },
   };
 }
@@ -143,7 +187,8 @@ export function resolveGatewayCredentials(
   return buildCredentials(
     getHeader("x-ninja-client-id"),
     getHeader("x-ninja-client-secret"),
-    getHeader("x-ninja-region")
+    getHeader("x-ninja-region"),
+    getHeader("x-ninja-scopes")
   );
 }
 
@@ -328,7 +373,7 @@ export async function createMcpServer(
         const stack = error instanceof Error ? error.stack : undefined;
         logger.error("Tool call failed", { tool: name, error: message, stack });
         return {
-          content: [{ type: "text", text: `Error: ${message}` }],
+          content: [{ type: "text", text: formatToolError(error) }],
           isError: true,
         };
       }

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -16,7 +16,14 @@
  */
 import { NinjaOneClient } from "@wyre-technology/node-ninjaone";
 import { AsyncLocalStorage } from "node:async_hooks";
-import { isValidRegion, getBaseUrlForRegion, type NinjaOneRegion } from "./types.js";
+import {
+  isValidRegion,
+  getBaseUrlForRegion,
+  parseScopes,
+  CONFIG_PLACEHOLDER,
+  type NinjaOneRegion,
+  type NinjaOneScope,
+} from "./types.js";
 import { logger } from "./logger.js";
 
 export interface NinjaOneCredentials {
@@ -24,14 +31,13 @@ export interface NinjaOneCredentials {
   clientSecret: string;
   region: NinjaOneRegion;
   baseUrl: string;
+  /**
+   * OAuth scopes to request. Omitted means "not configured" — the SDK's own
+   * default (monitoring + management) applies. Set this when the API Services
+   * app is granted a narrower set, or the token request 400s.
+   */
+  scopes?: NinjaOneScope[];
 }
-
-/**
- * Matches an unresolved MCPB/DXT config placeholder, e.g. "${user_config.ninjaone_region}".
- * When an optional user_config field is left blank, Claude Desktop injects the literal
- * placeholder string (not empty, not omitted) into the env var. Treat it as unset.
- */
-const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
 
 let _client: NinjaOneClient | null = null;
 let _credentials: NinjaOneCredentials | null = null;
@@ -59,6 +65,9 @@ export async function createClientDirect(
     clientId: creds.clientId,
     clientSecret: creds.clientSecret,
     baseUrl: creds.baseUrl,
+    // Passing `undefined` leaves the SDK default intact; passing `[]` would
+    // send an empty `scope` parameter, which is a different request.
+    ...(creds.scopes ? { scopes: creds.scopes } : {}),
   });
 }
 
@@ -98,8 +107,9 @@ export function getCredentials(): NinjaOneCredentials | null {
 
   const region = isValidRegion(regionEnv) ? regionEnv : "us";
   const baseUrl = getBaseUrlForRegion(region);
+  const scopes = parseScopes(process.env.NINJAONE_SCOPES);
 
-  return { clientId, clientSecret, region, baseUrl };
+  return { clientId, clientSecret, region, baseUrl, scopes };
 }
 
 /**
@@ -128,7 +138,8 @@ export async function getClient(): Promise<NinjaOneClient> {
     _credentials &&
     (creds.clientId !== _credentials.clientId ||
       creds.clientSecret !== _credentials.clientSecret ||
-      creds.region !== _credentials.region)
+      creds.region !== _credentials.region ||
+      (creds.scopes ?? []).join(" ") !== (_credentials.scopes ?? []).join(" "))
   ) {
     logger.info("Credentials changed, recreating client");
     _client = null;
@@ -136,11 +147,16 @@ export async function getClient(): Promise<NinjaOneClient> {
 
   if (!_client) {
     try {
-      logger.info("Creating NinjaOne client", { region: creds.region, baseUrl: creds.baseUrl });
+      logger.info("Creating NinjaOne client", {
+        region: creds.region,
+        baseUrl: creds.baseUrl,
+        scopes: creds.scopes ?? "sdk default (monitoring, management)",
+      });
       _client = new NinjaOneClient({
         clientId: creds.clientId,
         clientSecret: creds.clientSecret,
         baseUrl: creds.baseUrl,
+        ...(creds.scopes ? { scopes: creds.scopes } : {}),
       });
       _credentials = creds;
     } catch (error) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,6 +2,14 @@
  * Shared types for the NinjaOne MCP server
  */
 import type { Tool } from "@modelcontextprotocol/server";
+import { logger } from "./logger.js";
+
+/**
+ * Matches an unresolved MCPB/DXT config placeholder, e.g. "${user_config.ninjaone_region}".
+ * When an optional user_config field is left blank, Claude Desktop injects the literal
+ * placeholder string (not empty, not omitted) into the env var. Treat it as unset.
+ */
+export const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
 
 /**
  * Tool call result type - inline definition for MCP SDK compatibility
@@ -50,6 +58,60 @@ export type NinjaOneRegion = "us" | "eu" | "oc" | "ca" | "us2" | "fed";
  */
 export function isValidRegion(value: string): value is NinjaOneRegion {
   return ["us", "eu", "oc", "ca", "us2", "fed"].includes(value);
+}
+
+/**
+ * OAuth scopes a NinjaOne API Services app can be granted.
+ */
+export type NinjaOneScope = "monitoring" | "management" | "control";
+
+const VALID_SCOPES: NinjaOneScope[] = ["monitoring", "management", "control"];
+
+/**
+ * Parse a configured scope list (`NINJAONE_SCOPES`, or the gateway's
+ * `X-Ninja-Scopes` header) into the scopes to request at the token endpoint.
+ *
+ * Returns `undefined` for "not configured", which leaves the SDK's own default
+ * in place. That distinction matters: NinjaOne rejects a client_credentials
+ * request asking for a scope the app was never granted (400 `invalid_scope`)
+ * rather than narrowing the grant, so an app scoped to monitoring only cannot
+ * get a token at all unless the caller says so. Requesting *more* than you were
+ * granted is the failure mode — never widen this on a caller's behalf.
+ *
+ * Accepts comma- or space-separated values, in any case. Unrecognized entries
+ * are dropped with a warning rather than failing startup, mirroring how an
+ * invalid region degrades to "us" above.
+ */
+export function parseScopes(raw: string | undefined): NinjaOneScope[] | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed || CONFIG_PLACEHOLDER.test(trimmed)) {
+    return undefined;
+  }
+
+  const requested = trimmed
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map((s) => s.toLowerCase());
+
+  const valid = requested.filter((s): s is NinjaOneScope =>
+    (VALID_SCOPES as string[]).includes(s)
+  );
+  const unknown = requested.filter((s) => !(VALID_SCOPES as string[]).includes(s));
+
+  if (unknown.length > 0) {
+    logger.warn("Ignoring unrecognized NinjaOne scope(s)", {
+      ignored: unknown,
+      valid: VALID_SCOPES,
+    });
+  }
+
+  // Nothing usable (e.g. a pure typo) — fall back to the SDK default rather
+  // than sending an empty `scope` parameter, which is not the same as omitting it.
+  if (valid.length === 0) {
+    return undefined;
+  }
+
+  return [...new Set(valid)];
 }
 
 /**


### PR DESCRIPTION
## Problem

Reported in the community: with a NinjaOne **API Services** app scoped to
**monitoring only** (v2.2.6, `NINJAONE_REGION=eu`, HTTP transport), *every*
tool call failed with `Failed to acquire token: 400`. Enabling `management`
made it work.

That is our bug, not a NinjaOne requirement.

## Root cause

The server never passed `scopes` when constructing the client — `createClientDirect()`
and `getClient()` set only `clientId`/`clientSecret`/`baseUrl`. So the SDK default applied:

```js
// @wyre-technology/node-ninjaone/dist/index.js:36
scopes: config.scopes ?? ["monitoring", "management"],
```

and that fixed pair went straight into the token request:

```js
// dist/index.js:172-177
grant_type: "client_credentials",
scope: this.config.scopes.join(" ")   // → "monitoring management"
```

NinjaOne rejects a `client_credentials` request naming a scope the app was never
granted — `400 invalid_scope` — rather than narrowing the grant. RFC 6749 §3.3
permits either behavior; NinjaOne picked reject.

So the failure is at the **token** step, before any tool logic runs. That's why
*every* call failed, including pure reads like `devices_list` that need nothing
beyond monitoring. Granting `management` didn't supply a permission the tools
needed — it just made our hardcoded scope string valid again.

Two secondary defects fell out of the same trace:

- **The error was unreadable.** The SDK captures the OAuth response body on
  `NinjaOneError.response`, but the tool-call handler surfaced only `error.message`.
  The reporter never saw `invalid_scope` — the one word that explains it.
- **Scopes were undocumented.** The README's Authentication section never mentioned
  which app permissions to grant, and the config table had no scope variable.

## Fix

- `NINJAONE_SCOPES` env var (comma- or space-separated, case-insensitive), and
  `X-Ninja-Scopes` per request in gateway mode. **Default is unchanged** —
  existing deployments that do writes are unaffected; a monitoring-only app now
  sets `NINJAONE_SCOPES=monitoring` and works.
- Unrecognized scope values are dropped with a warning rather than failing
  startup, mirroring how an invalid region degrades to `us`. Nothing valid left
  → fall back to the SDK default rather than send an empty `scope` parameter,
  which is a different request from omitting it.
- Tool errors now append the upstream response body, and an `invalid_scope`
  rejection additionally explains how to fix it.
- README documents which scope each tool family needs; MCPB manifest gains an
  optional `ninjaone_scopes` field.

## Testing

`npx vitest run` → **191 passed**, 1 failed.

The one failure is `gateway-concurrency.test.ts` (`SyntaxError: Unexpected token
'e', "event: mes"... is not valid JSON` — SSE framing vs `JSON.parse`). It is
**pre-existing and unrelated**: I verified it fails identically with the three
modified source files reverted to `HEAD`. Not addressed here.

`tsc --noEmit` and `eslint src` are clean.

New coverage:
- `parseScopes` — parsing, dedupe, case/whitespace, invalid-value handling, MCPB placeholder
- scopes reach the SDK constructor (the actual regression), stay absent when unconfigured,
  invalidate the cached client when changed, and flow through gateway-scoped credentials
- `formatToolError` — body appended, scope hint added only for `invalid_scope`, no duplication

## Not in this PR

Whether NinjaOne accepts an **omitted** `scope` parameter (which would let us stop
asserting scopes altogether and make this class of bug impossible) is unverified —
no NinjaOne credentials are reachable from either secrets context, so I could not
test it. Requesting *all* scopes would be strictly worse: it would break any app
without `control`. Parked pending a curl against a real restricted app.

The SDK's own default is untouched; it also has no way to express omission
(`scopes?: NinjaOneScope[]`, where `[]` sends `scope=""`). Worth a companion
change once the above is settled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/ninjaone-mcp/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789564295&installation_model_id=431410&pr_number=87&repository=wyre-technology%2Fninjaone-mcp&return_to=https%3A%2F%2Fgithub.com%2Fwyre-technology%2Fninjaone-mcp%2Fpull%2F87&signature=c01d3ff2f0c37c5a1bba4b6b574645e8c1360f8e2c19f4972e84094f80e52dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->