### PR TITLE
fix(auth): preflight token check at startup, fix IPv4-only healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@
   `Failed to acquire token: 400 Bad Request` with the one diagnostic word —
   `invalid_scope` — thrown away. The body is now appended, and an
   `invalid_scope` rejection additionally explains how to fix it.
+- **A bad token exchange (scope mismatch, revoked credentials, etc.) surfaced
+  on every tool call instead of at boot.** The HTTP transport now makes one
+  authenticated request at startup (env mode only — gateway mode has no static
+  credentials to check until a request supplies them via headers) and exits
+  loudly with the upstream response body if it fails, so a misconfigured
+  deployment reads as "server won't start, here's why" in the container logs
+  instead of "every tool mysteriously errors."
+- **The Docker healthcheck has never passed for IPv4-only deployments.** It
+  probed `http://localhost:8080/health`, but inside the container `localhost`
+  resolves to `::1` while the server binds `MCP_HTTP_HOST=0.0.0.0`
+  (IPv4-only), so `wget` got connection refused and the container reported
+  unhealthy indefinitely even though the endpoint itself was fine — breaking
+  `depends_on: condition: service_healthy` for anyone sequencing startup on
+  it. The probe also hardcoded port 8080 while `MCP_HTTP_PORT` is
+  configurable, so changing the port landed in the same permanently-unhealthy
+  state. Both the Dockerfile `HEALTHCHECK` and `docker-compose.yml` now probe
+  `127.0.0.1` on `$MCP_HTTP_PORT` (default `8080`).
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,14 @@ USER ninjaone
 # Expose port for HTTP transport
 EXPOSE 8080
 
-# Health check against the HTTP endpoint
+# Health check against the HTTP endpoint. Use 127.0.0.1, not localhost: inside
+# the container localhost resolves to ::1 (IPv6), but the server binds
+# MCP_HTTP_HOST=0.0.0.0 (IPv4-only), so an IPv6 probe gets connection refused
+# and the container reports unhealthy forever even though the endpoint is
+# fine. Read the port from MCP_HTTP_PORT so a non-default port doesn't hit
+# the same failure mode.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider "http://127.0.0.1:${MCP_HTTP_PORT:-8080}/health" || exit 1
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ services:
       # Mount logs directory for persistence
       - ninjaone-mcp-logs:/app/logs
 
-    # Health check
+    # Health check. 127.0.0.1, not localhost (resolves to ::1 in-container,
+    # which the IPv4-only MCP_HTTP_HOST=0.0.0.0 bind refuses); port comes from
+    # MCP_HTTP_PORT so overriding it doesn't strand the healthcheck on 8080.
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://127.0.0.1:${MCP_HTTP_PORT:-8080}/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -8,6 +8,7 @@ import {
   getClient,
   clearClient,
   runWithCredentials,
+  preflightAuthCheck,
 } from "../utils/client.js";
 import * as clientModule from "../utils/client.js";
 
@@ -395,6 +396,53 @@ describe("NinjaOne Client Utilities", () => {
       expect(constructedConfigs).toHaveLength(2);
       expect(constructedConfigs[0]).toMatchObject({ clientId: "test-id" });
       expect(constructedConfigs[1]).toMatchObject({ clientId: "test-id" });
+    });
+  });
+
+  // Regression: a scope mismatch was fatal at the token exchange behind
+  // every tool call, but silent at boot — "all the tools mysteriously
+  // error" with no indication why until you read one tool's error body.
+  // preflightAuthCheck() makes one cheap authenticated call at startup so
+  // that failure surfaces once, loudly, with the upstream body attached.
+  describe("preflightAuthCheck", () => {
+    it("skips the check (not checked) when no credentials are configured", async () => {
+      delete process.env.NINJAONE_CLIENT_ID;
+      delete process.env.NINJAONE_CLIENT_SECRET;
+
+      await expect(preflightAuthCheck()).resolves.toEqual({ checked: false });
+    });
+
+    it("passes (checked, no error) when the token exchange succeeds", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_REGION = "us";
+
+      const client = (await getClient()) as unknown as {
+        organizations: { list: ReturnType<typeof vi.fn> };
+      };
+      client.organizations.list.mockResolvedValueOnce([]);
+
+      await expect(preflightAuthCheck()).resolves.toEqual({ checked: true });
+      expect(client.organizations.list).toHaveBeenCalledWith({ pageSize: 1 });
+    });
+
+    it("fails with the upstream body when the token exchange is rejected", async () => {
+      process.env.NINJAONE_CLIENT_ID = "test-id";
+      process.env.NINJAONE_CLIENT_SECRET = "test-secret";
+      process.env.NINJAONE_SCOPES = "monitoring,management";
+
+      const client = (await getClient()) as unknown as {
+        organizations: { list: ReturnType<typeof vi.fn> };
+      };
+      const authError = new Error("Failed to acquire token: 400 Bad Request");
+      (authError as unknown as { response: string }).response = '{"error":"invalid_scope"}';
+      client.organizations.list.mockRejectedValueOnce(authError);
+
+      const result = await preflightAuthCheck();
+      expect(result.checked).toBe(true);
+      expect(result.error).toContain("Failed to acquire token: 400 Bad Request");
+      expect(result.error).toContain("invalid_scope");
+      expect(result.error).toContain("NINJAONE_SCOPES");
     });
   });
 

--- a/src/__tests__/tool-errors.test.ts
+++ b/src/__tests__/tool-errors.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { formatToolError } from "../mcp-server.js";
+import { formatToolError } from "../utils/client.js";
 
 class FakeNinjaOneError extends Error {
   readonly statusCode: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
   makeMcpServerFactory,
   resolveGatewayCredentials,
 } from "./mcp-server.js";
+import { preflightAuthCheck } from "./utils/client.js";
 import { logger } from "./utils/logger.js";
 import { verifyS2sHeader, S2S_HEADER } from "./s2s-verify.js";
 
@@ -65,6 +66,26 @@ async function startHttpTransport(): Promise<void> {
   const port = parseInt(process.env.MCP_HTTP_PORT || "8080", 10);
   const host = process.env.MCP_HTTP_HOST || "0.0.0.0";
   const isGatewayMode = process.env.AUTH_MODE === "gateway";
+
+  // A scope mismatch (or any other OAuth-level rejection) is otherwise silent
+  // at boot and fatal on the token exchange behind *every* tool call — "all
+  // the tools mysteriously error", diagnosable only by reading a single
+  // tool's error body. This turns that into "server won't start, here's why"
+  // in the container logs. env mode only: gateway mode has no static
+  // credentials to check at startup, they only arrive per-request via
+  // headers (same reasoning as the /health handler below never calling
+  // getCredentials()).
+  if (!isGatewayMode) {
+    const preflight = await preflightAuthCheck();
+    if (preflight.error) {
+      // Propagates to main().catch() below, which logs and exits(1) — the
+      // same fatal-startup handling every other boot-time failure gets.
+      throw new Error(preflight.error);
+    }
+    if (preflight.checked) {
+      logger.info("Preflight authentication check passed");
+    }
+  }
 
   // legacy: 'stateless' (also the default) is the dual-era posture: 2025-era
   // traffic is answered per-request statelessly, modern 2026-07-28 envelope

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -23,6 +23,7 @@ import {
 import {
   getCredentials,
   runWithCredentials,
+  formatToolError,
   type NinjaOneCredentials,
 } from "./utils/client.js";
 import { logger } from "./utils/logger.js";
@@ -101,47 +102,6 @@ const statusTool: Tool = {
     properties: {},
   },
 };
-
-/**
- * Render a thrown error as the text a tool call reports back.
- *
- * The SDK's error classes carry the upstream response body on `.response`, but
- * only `.message` used to be surfaced — so an OAuth failure read as a bare
- * "Failed to acquire token: 400 Bad Request" with no reason attached. The body
- * is where `invalid_scope` lives, and that one word is the whole diagnosis.
- */
-export function formatToolError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-
-  const raw = (error as { response?: unknown } | null)?.response;
-  const body =
-    typeof raw === "string" ? raw : raw != null ? safeStringify(raw) : undefined;
-
-  const parts = [`Error: ${message}`];
-  if (body && !message.includes(body)) {
-    parts.push(body);
-  }
-
-  // An invalid_scope rejection is fully self-inflicted and fully fixable, so
-  // say how rather than leaving the operator to infer it from an OAuth code.
-  if (body?.includes("invalid_scope")) {
-    parts.push(
-      "The API Services app does not grant every requested OAuth scope. Set NINJAONE_SCOPES " +
-        "to the scopes it actually has (e.g. NINJAONE_SCOPES=monitoring), or grant the missing " +
-        "scope in NinjaOne under Administration > Apps > API."
-    );
-  }
-
-  return parts.join("\n");
-}
-
-function safeStringify(value: unknown): string | undefined {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return undefined;
-  }
-}
 
 /**
  * Build a validated NinjaOneCredentials object from raw values.

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -172,6 +172,71 @@ export async function getClient(): Promise<NinjaOneClient> {
 }
 
 /**
+ * Verify the configured credentials can actually acquire a token, by making
+ * one cheap authenticated call (organizations, minimal page size — available
+ * under every OAuth scope). `checked` is false when no credentials are
+ * configured yet — `getClient()` already reports that clearly on the first
+ * tool call, so there's nothing to preflight. `error` (with the upstream
+ * response body already folded in via `formatToolError`) is only set when
+ * the check ran and failed.
+ */
+export async function preflightAuthCheck(): Promise<{ checked: boolean; error?: string }> {
+  if (!getCredentials()) {
+    return { checked: false };
+  }
+
+  try {
+    const client = await getClient();
+    await client.organizations.list({ pageSize: 1 });
+    return { checked: true };
+  } catch (error) {
+    return { checked: true, error: formatToolError(error) };
+  }
+}
+
+/**
+ * Render a thrown error as the text a tool call (or the startup preflight
+ * check) reports back.
+ *
+ * The SDK's error classes carry the upstream response body on `.response`, but
+ * only `.message` used to be surfaced — so an OAuth failure read as a bare
+ * "Failed to acquire token: 400 Bad Request" with no reason attached. The body
+ * is where `invalid_scope` lives, and that one word is the whole diagnosis.
+ */
+export function formatToolError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  const raw = (error as { response?: unknown } | null)?.response;
+  const body =
+    typeof raw === "string" ? raw : raw != null ? safeStringify(raw) : undefined;
+
+  const parts = [`Error: ${message}`];
+  if (body && !message.includes(body)) {
+    parts.push(body);
+  }
+
+  // An invalid_scope rejection is fully self-inflicted and fully fixable, so
+  // say how rather than leaving the operator to infer it from an OAuth code.
+  if (body?.includes("invalid_scope")) {
+    parts.push(
+      "The API Services app does not grant every requested OAuth scope. Set NINJAONE_SCOPES " +
+        "to the scopes it actually has (e.g. NINJAONE_SCOPES=monitoring), or grant the missing " +
+        "scope in NinjaOne under Administration > Apps > API."
+    );
+  }
+
+  return parts.join("\n");
+}
+
+function safeStringify(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Clear the cached client (useful for testing)
  */
 export function clearClient(): void {


### PR DESCRIPTION
## Summary

Two follow-ups from community feedback on the `NINJAONE_SCOPES` fix in #87:

- **Startup preflight.** A scope mismatch (or any other OAuth-level rejection) is fatal at the token exchange, so it previously surfaced on *every* tool call instead of at boot — "all the tools mysteriously error", diagnosable only by reading one tool's error body. The HTTP transport now makes one cheap authenticated call (`organizations.list({ pageSize: 1 })`) at startup and exits loudly with the upstream response body on failure. env mode only — gateway mode has no static credentials to check until a request supplies them via headers.
- **IPv4-only healthcheck.** The Docker healthcheck has never passed for anyone on the default `MCP_HTTP_HOST=0.0.0.0` bind: it probed `localhost`, which resolves to `::1` inside the container and gets connection refused (the server is IPv4-only), so the container reported unhealthy indefinitely regardless of actual health — breaking `depends_on: condition: service_healthy`. The probe also hardcoded port 8080 while `MCP_HTTP_PORT` is configurable. Both the Dockerfile `HEALTHCHECK` and `docker-compose.yml` now probe `127.0.0.1` on `$MCP_HTTP_PORT`.

`formatToolError` moved from `mcp-server.ts` into `utils/client.ts` (colocated with `getClient()`/`getCredentials()`) so the preflight check can format its own failures the same way tool calls do, without a circular import.

## Verified

- `npm run typecheck` / `npm run lint` / `npm run build`: clean
- `npm test`: 194/195 passing (1 pre-existing, unrelated failure on `main` — SSE parsing in `gateway-concurrency.test.ts`, reproduced identically on a clean checkout before this branch)
- Real `docker build` + container run:
  - `wget http://localhost:8080/health` inside the container → connection refused (reproduces the bug)
  - `wget http://127.0.0.1:8080/health` → succeeds
  - Docker's actual `HEALTHCHECK` reports `healthy`, `FailingStreak: 0`, both at the default port and with `MCP_HTTP_PORT=9090`
  - `AUTH_MODE=env` with bad credentials → container exits 1 immediately, upstream token-endpoint body logged (`Client app not exist`)

## Test plan

- [x] Unit tests for `preflightAuthCheck()` (no creds / success / upstream rejection)
- [x] Live Docker build + healthcheck verification (see above)
- [x] Live preflight verification against the real NinjaOne token endpoint with invalid credentials

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wyre-technology/codesmith/ninjaone-mcp/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->