### PR TITLE
fix(status): stop advising callers to use suppressed *_navigate tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Fixed
 
+- **`ninjaone_status` and the unknown-tool error advised calling
+  `ninjaone_navigate` to discover tools without qualification.** Conduit
+  suppresses `*_navigate` / `*_back` at the gateway (tier filtering lives in
+  the grant resolver, which the container cannot see) and replaces them with
+  `conduit__my_access`, so that advice pointed callers behind the gateway at
+  a tool that returns method-not-found. Both strings now point to
+  `conduit__my_access` for gateway callers and keep `ninjaone_navigate` as
+  the standalone-mode discovery path. The tool itself is unchanged.
+  (WYRE-AI/conduit#1236)
 - **A monitoring-only API app could not authenticate at all.** The server never
   passed an explicit scope list to the SDK, so every token request fell through
   to the SDK default of `["monitoring", "management"]` and asked for

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -294,7 +294,7 @@ export async function createMcpServer(
             content: [
               {
                 type: "text",
-                text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nAll tools are available. Use ninjaone_navigate to discover tools by domain.`,
+                text: `NinjaOne MCP Server Status\n\nCredentials: ${credStatus}\nAvailable domains: ${getAvailableDomains().join(", ")}\n\nCall conduit__my_access to see which tools you can use under the gateway, or ninjaone_navigate to browse all tools by domain when running standalone.`,
               },
             ],
           };
@@ -323,7 +323,7 @@ export async function createMcpServer(
           content: [
             {
               type: "text",
-              text: `Unknown tool: ${name}. Use ninjaone_navigate to discover available tools by domain.`,
+              text: `Unknown tool: ${name}. Call conduit__my_access to see which tools you can use under the gateway, or ninjaone_navigate to browse available tools by domain when running standalone.`,
             },
           ],
           isError: true,


### PR DESCRIPTION
## Summary
- `ninjaone_status` and the unknown-tool error unconditionally told callers to use `ninjaone_navigate` to discover tools (status also claimed "all tools are available at all times").
- Conduit's gateway suppresses `*_navigate`/`*_back` from `tools/list`/`tools/call` and replaces them with the tier-true `conduit__my_access`, since the container can't see the caller's tier. Following the old advice behind the gateway returns method-not-found.
- Both strings now point gateway callers at `conduit__my_access` and keep `ninjaone_navigate` as the standalone-mode discovery path. The navigate/back tools themselves are untouched (per the issue, leaning keep-and-suppress).
- Pure text fix — no security/enforcement logic involved.

## Test plan
- [x] `npm run typecheck` (or `lint`/tsc --noEmit) — passes
- [x] `npm run build` — passes
- [x] `npm test` — passes (full suite green)

Refs WYRE-AI/conduit#1236

https://claude.ai/code/session_01KMN98C4nHp5pJLdB2ksXud

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/ninjaone-mcp/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790527197&installation_model_id=431408&pr_number=90&repository=WYRE-AI%2Fninjaone-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fninjaone-mcp%2Fpull%2F90&signature=7747dda65e6127e29a147d6c1f9ccf8abcacc2562890817e2776253acf4a1b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->