### PR TITLE
ci(release): bump mcp-server-release.yml pin to pick up cosign/sigstore verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       id-token: write
       security-events: write
-    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@07bc1921cbd01ad8a079fe8a3dd28180080870d5
+    uses: WYRE-AI/.github/.github/workflows/mcp-server-release.yml@8c2360058e882a8afacfc4cebf840135789ef406
     with:
       server-name: ninjaone-mcp
       image-name: ghcr.io/wyre-ai/ninjaone-mcp
@@ -44,7 +44,7 @@ jobs:
   #   permissions:
   #     id-token: write
   #     contents: read
-  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@07bc1921cbd01ad8a079fe8a3dd28180080870d5
+  #   uses: WYRE-AI/.github/.github/workflows/mcp-server-deploy.yml@8c2360058e882a8afacfc4cebf840135789ef406
   #   with:
   #     vendor-slug: ninjaone
   #     image-name: ghcr.io/wyre-ai/ninjaone-mcp


### PR DESCRIPTION
## Summary

Bumps the pinned `WYRE-AI/.github/.github/workflows/mcp-server-release.yml` reusable-workflow commit from `07bc1921` to `8c236005` (current main tip).

`07bc1921` (2026-08-24) predates `WYRE-AI/.github#2` (merged 2026-08-27, warden's Gate-3-reviewed fix), which added cosign/Sigstore signature verification of the `mcp-publisher` binary before extraction — until this bump, this repo's release job installs `mcp-publisher` with **zero pin, checksum, or signature check**. `8c236005` is 3 commits past the fix; those 3 commits don't touch `mcp-server-release.yml` (confirmed via diff), so it's safe to bump straight to current tip rather than pin to the fix commit exactly.

**Identical mechanical change across all affected `*-mcp` repos** (found via a full org enumeration cross-checked with warden's independent scan — 53 repos, same result). Part of a coordinated class-ask, not merged individually; holding for the batched Aaron authorization (mcp repos are walled).

## Test plan

- [x] Confirmed the new sha's file content includes the cosign verify-blob step (diffed directly, not inferred)
- [x] Confirmed the 3 commits between the fix and this bump's target don't touch the reusable workflow file
- N/A — no functional test beyond the workflow reference itself; CI will exercise the new pin on the next real release from this repo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/ninjaone-mcp/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790609693&installation_model_id=431408&pr_number=91&repository=WYRE-AI%2Fninjaone-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fninjaone-mcp%2Fpull%2F91&signature=9b81bb4ed63dd8a5bc5421896575113ba011ab769be70ef28c5fdbdbe0fac399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->