### PR TITLE
feat: add custom fields support for devices and organizations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@
 - `.releaserc.json`: commit message templates must use `\n` escape sequences, never literal newlines
 
 ### Vendor Client Library Usage
-- Use the corresponding `@wyre-technology/node-*` client library for API calls, not raw `fetch`
+- Use the corresponding `@wyre-ai/node-*` client library for API calls, not raw `fetch`
 - Client library methods should handle auth header construction — don't duplicate auth logic in the MCP server
 - Error responses from vendor APIs should be mapped to meaningful MCP error messages, not passed through raw
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@
 # since those can carry behavioural breaking changes a green test suite misses.
 version: 2
 
-# @wyre-technology/* packages are hosted on GitHub Packages (npm.pkg.github.com),
+# @wyre-ai/* packages are hosted on GitHub Packages (npm.pkg.github.com),
 # which has no anonymous read. Without this, Dependabot's own version-resolution
 # job for the root npm group (the one that touches this repo's own
-# @wyre-technology/node-<vendor> dependency) fails with
+# @wyre-ai/node-<vendor> dependency) fails with
 # private_source_authentication_failure -- it can update every OTHER dependency
 # fine, just not this one. GHPKG_READ_TOKEN is an existing org-level Dependabot
 # secret (created 2026-06-05); this just wires it in. See task_1783631373373.

--- a/.npmrc
+++ b/.npmrc
@@ -1,10 +1,9 @@
-# @wyre-technology/* packages are hosted on the GitHub Packages npm registry.
+# @wyre-ai/* packages are hosted on the GitHub Packages npm registry.
 # GitHub Packages has no anonymous read: every install needs a token with
 # `read:packages`, even for public packages. The token is read from the
 # NODE_AUTH_TOKEN environment variable so the same .npmrc works in:
 #   - CI (actions/setup-node sets NODE_AUTH_TOKEN)
 #   - one-click deploys (operators set NODE_AUTH_TOKEN as a build variable)
 #   - local dev (run `export NODE_AUTH_TOKEN=$(gh auth token)` once)
-@wyre-technology:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
 @wyre-ai:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies with GitHub Packages auth
-RUN echo "@wyre-technology:registry=https://npm.pkg.github.com" > .npmrc && \
+RUN echo "@wyre-ai:registry=https://npm.pkg.github.com" > .npmrc && \
     echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc && \
     npm ci --ignore-scripts && \
     rm -f .npmrc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Model Context Protocol (MCP) server for interacting with NinjaOne, featuring a
 ## One-Click Deployment
 
 > [!IMPORTANT]
-> **Before you click:** this server depends on `@wyre-technology/node-ninjaone`,
+> **Before you click:** this server depends on `@wyre-ai/node-ninjaone`,
 > which is hosted on the **GitHub Packages** npm registry. GitHub Packages has no
 > anonymous access — even though the package is public, every `npm install` needs a
 > token. The cloud builder runs `npm install` for you, so you must give it one, or
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for interacting with NinjaOne, featuring a
 > 1. Create a GitHub **Personal Access Token** with the `read:packages` scope
 >    ([classic token](https://github.com/settings/tokens/new?scopes=read:packages&description=ninjaone-mcp%20deploy)).
 >    Any GitHub account works — you do **not** need to be a member of the
->    `wyre-technology` org to read its public packages.
+>    `wyre-ai` org to read its public packages.
 > 2. Add it as a build variable when prompted by the deploy flow:
 >    - **Cloudflare Workers** → set a build variable named **`NODE_AUTH_TOKEN`** to your PAT
 >      (Workers → Settings → Build → Variables and Secrets).
@@ -62,7 +62,7 @@ export NODE_AUTH_TOKEN=$(gh auth token)   # or a PAT with read:packages
 npm install @wyre-ai/ninjaone-mcp
 ```
 
-The repo's `.npmrc` already points the `@wyre-technology` scope at GitHub Packages and
+The repo's `.npmrc` already points the `@wyre-ai` scope at GitHub Packages and
 reads the token from `NODE_AUTH_TOKEN`, so no further config is needed. The same applies
 to `npx @wyre-ai/ninjaone-mcp` below. Prefer a zero-setup option? Use the prebuilt
 container image (`ghcr.io/wyre-ai/ninjaone-mcp`) or the `.mcpb` bundle attached to
@@ -143,6 +143,8 @@ Tools:
 - `ninjaone_devices_services` - List Windows services on a device
 - `ninjaone_devices_alerts` - Get device-specific alerts
 - `ninjaone_devices_activities` - View device activity log
+- `ninjaone_devices_get_custom_fields` - Get device custom fields
+- `ninjaone_devices_update_custom_fields` - Update device custom fields
 
 ### Organizations
 Manage customer organizations and their resources.
@@ -153,6 +155,8 @@ Tools:
 - `ninjaone_organizations_create` - Create a new organization
 - `ninjaone_organizations_locations` - List organization locations
 - `ninjaone_organizations_devices` - List devices for an organization
+- `ninjaone_organizations_get_custom_fields` - Get organization custom fields
+- `ninjaone_organizations_update_custom_fields` - Update organization custom fields
 
 ### Alerts
 View and manage alerts across all devices.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/server": "^2.0.0",
-        "@wyre-technology/node-ninjaone": "^2.0.1"
+        "@wyre-ai/node-ninjaone": "^2.1.0"
       },
       "bin": {
         "ninjaone-mcp": "dist/index.js"
@@ -1737,10 +1737,10 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@wyre-technology/node-ninjaone": {
-      "version": "2.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@wyre-technology/node-ninjaone/2.0.1/eee791617aba3ca1920dfa54a46288fb20e92f01",
-      "integrity": "sha512-DUvO4v9dGLNIDF5shblNuPpRDV5Emxx3htkIG4MOAG5kwjRdEXsUJNQFphpdDR+Xj9FWqC8MSoKk3iZeR2022A==",
+    "node_modules/@wyre-ai/node-ninjaone": {
+      "version": "2.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@wyre-ai/node-ninjaone/2.1.0/eba4af62bfa492e97039c59b229378c1fee4e030",
+      "integrity": "sha512-PuooQq7W63yFgba9Y4f28W7MJPXABFt8XtI8wwkECExMlU8rfaK2Hd+HfDmnhCZnoRcgX+39kxfYuSRsreJMJA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
-    "@wyre-technology/node-ninjaone": "^2.0.1"
+    "@wyre-ai/node-ninjaone": "^2.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -32,7 +32,7 @@ const { NinjaOneClientMock, constructedConfigs } = vi.hoisted(() => ({
 }));
 
 // Mock the node-ninjaone library
-vi.mock("@wyre-technology/node-ninjaone", () => ({
+vi.mock("@wyre-ai/node-ninjaone", () => ({
   NinjaOneClient: NinjaOneClientMock,
 }));
 

--- a/src/__tests__/domains/devices.test.ts
+++ b/src/__tests__/domains/devices.test.ts
@@ -13,6 +13,8 @@ const {
   mockDevicesGetServices,
   mockAlertsListByDevice,
   mockDevicesGetActivities,
+  mockDevicesGetCustomFields,
+  mockDevicesUpdateCustomFields,
   mockClient,
 } = vi.hoisted(() => {
   const mockDevicesList = vi.fn();
@@ -22,6 +24,8 @@ const {
   const mockDevicesGetServices = vi.fn();
   const mockAlertsListByDevice = vi.fn();
   const mockDevicesGetActivities = vi.fn();
+  const mockDevicesGetCustomFields = vi.fn();
+  const mockDevicesUpdateCustomFields = vi.fn();
 
   const mockClient = {
     devices: {
@@ -31,6 +35,8 @@ const {
       reboot: mockDevicesReboot,
       getServices: mockDevicesGetServices,
       getActivities: mockDevicesGetActivities,
+      getCustomFields: mockDevicesGetCustomFields,
+      updateCustomFields: mockDevicesUpdateCustomFields,
     },
     alerts: {
       listByDevice: mockAlertsListByDevice,
@@ -45,6 +51,8 @@ const {
     mockDevicesGetServices,
     mockAlertsListByDevice,
     mockDevicesGetActivities,
+    mockDevicesGetCustomFields,
+    mockDevicesUpdateCustomFields,
     mockClient,
   };
 });
@@ -74,6 +82,8 @@ describe("Devices Domain Handler", () => {
     mockDevicesGetServices.mockClear();
     mockAlertsListByDevice.mockClear();
     mockDevicesGetActivities.mockClear();
+    mockDevicesGetCustomFields.mockClear();
+    mockDevicesUpdateCustomFields.mockClear();
 
     // Reset mock implementations - list returns Device[] directly
     mockDevicesList.mockResolvedValue([
@@ -107,13 +117,18 @@ describe("Devices Domain Handler", () => {
         { id: 1, type: "LOGIN", timestamp: "2024-01-01T00:00:00Z" },
       ],
     });
+    mockDevicesGetCustomFields.mockResolvedValue({
+      assetTag: "AT-4821",
+      warrantyExpiration: "2027-06-30",
+    });
+    mockDevicesUpdateCustomFields.mockResolvedValue(undefined);
   });
 
   describe("getTools", () => {
     it("should return all device tools", () => {
       const tools = devicesHandler.getTools();
 
-      expect(tools.length).toBe(6);
+      expect(tools.length).toBe(8);
 
       const toolNames = tools.map((t) => t.name);
       expect(toolNames).toContain("ninjaone_devices_list");
@@ -122,6 +137,8 @@ describe("Devices Domain Handler", () => {
       expect(toolNames).toContain("ninjaone_devices_services");
       expect(toolNames).toContain("ninjaone_devices_alerts");
       expect(toolNames).toContain("ninjaone_devices_activities");
+      expect(toolNames).toContain("ninjaone_devices_get_custom_fields");
+      expect(toolNames).toContain("ninjaone_devices_update_custom_fields");
     });
 
     it("ninjaone_devices_get should require device_id", () => {
@@ -364,6 +381,35 @@ describe("Devices Domain Handler", () => {
 
         const data = JSON.parse(result.content[0].text);
         expect(data.activities).toHaveLength(1);
+      });
+    });
+
+    describe("ninjaone_devices_get_custom_fields", () => {
+      it("should get device custom fields", async () => {
+        const result = await devicesHandler.handleCall("ninjaone_devices_get_custom_fields", {
+          device_id: 1,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockDevicesGetCustomFields).toHaveBeenCalledWith(1);
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.assetTag).toBe("AT-4821");
+      });
+    });
+
+    describe("ninjaone_devices_update_custom_fields", () => {
+      it("should update device custom fields", async () => {
+        const result = await devicesHandler.handleCall("ninjaone_devices_update_custom_fields", {
+          device_id: 1,
+          fields: { assetTag: "AT-9999" },
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(mockDevicesUpdateCustomFields).toHaveBeenCalledWith(1, { assetTag: "AT-9999" });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.success).toBe(true);
       });
     });
 

--- a/src/__tests__/domains/organizations.test.ts
+++ b/src/__tests__/domains/organizations.test.ts
@@ -10,6 +10,8 @@ const {
   mockOrganizationsGet,
   mockOrganizationsCreate,
   mockOrganizationsGetLocations,
+  mockOrganizationsGetCustomFields,
+  mockOrganizationsUpdateCustomFields,
   mockDevicesListByOrganization,
   mockClient,
 } = vi.hoisted(() => {
@@ -17,6 +19,8 @@ const {
   const mockOrganizationsGet = vi.fn();
   const mockOrganizationsCreate = vi.fn();
   const mockOrganizationsGetLocations = vi.fn();
+  const mockOrganizationsGetCustomFields = vi.fn();
+  const mockOrganizationsUpdateCustomFields = vi.fn();
   const mockDevicesListByOrganization = vi.fn();
 
   const mockClient = {
@@ -25,6 +29,8 @@ const {
       get: mockOrganizationsGet,
       create: mockOrganizationsCreate,
       getLocations: mockOrganizationsGetLocations,
+      getCustomFields: mockOrganizationsGetCustomFields,
+      updateCustomFields: mockOrganizationsUpdateCustomFields,
     },
     devices: {
       listByOrganization: mockDevicesListByOrganization,
@@ -36,6 +42,8 @@ const {
     mockOrganizationsGet,
     mockOrganizationsCreate,
     mockOrganizationsGetLocations,
+    mockOrganizationsGetCustomFields,
+    mockOrganizationsUpdateCustomFields,
     mockDevicesListByOrganization,
     mockClient,
   };
@@ -63,6 +71,8 @@ describe("Organizations Domain Handler", () => {
     mockOrganizationsGet.mockClear();
     mockOrganizationsCreate.mockClear();
     mockOrganizationsGetLocations.mockClear();
+    mockOrganizationsGetCustomFields.mockClear();
+    mockOrganizationsUpdateCustomFields.mockClear();
     mockDevicesListByOrganization.mockClear();
 
     // Reset mock implementations - list returns Organization[] directly
@@ -90,13 +100,18 @@ describe("Organizations Domain Handler", () => {
       { id: 1, systemName: "Device 1" },
       { id: 2, systemName: "Device 2" },
     ]);
+    mockOrganizationsGetCustomFields.mockResolvedValue({
+      accountManager: "Jane Smith",
+      contractType: "Managed Services",
+    });
+    mockOrganizationsUpdateCustomFields.mockResolvedValue(undefined);
   });
 
   describe("getTools", () => {
     it("should return all organization tools", () => {
       const tools = organizationsHandler.getTools();
 
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(7);
 
       const toolNames = tools.map((t) => t.name);
       expect(toolNames).toContain("ninjaone_organizations_list");
@@ -104,6 +119,8 @@ describe("Organizations Domain Handler", () => {
       expect(toolNames).toContain("ninjaone_organizations_create");
       expect(toolNames).toContain("ninjaone_organizations_locations");
       expect(toolNames).toContain("ninjaone_organizations_devices");
+      expect(toolNames).toContain("ninjaone_organizations_get_custom_fields");
+      expect(toolNames).toContain("ninjaone_organizations_update_custom_fields");
     });
 
     it("ninjaone_organizations_get should require organization_id", () => {
@@ -191,6 +208,38 @@ describe("Organizations Domain Handler", () => {
 
         const data = JSON.parse(result.content[0].text);
         expect(data).toHaveLength(2);
+      });
+    });
+
+    describe("ninjaone_organizations_get_custom_fields", () => {
+      it("should get organization custom fields", async () => {
+        const result = await organizationsHandler.handleCall(
+          "ninjaone_organizations_get_custom_fields",
+          { organization_id: 1 },
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(mockOrganizationsGetCustomFields).toHaveBeenCalledWith(1);
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.accountManager).toBe("Jane Smith");
+      });
+    });
+
+    describe("ninjaone_organizations_update_custom_fields", () => {
+      it("should update organization custom fields", async () => {
+        const result = await organizationsHandler.handleCall(
+          "ninjaone_organizations_update_custom_fields",
+          { organization_id: 1, fields: { accountManager: "John Doe" } },
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(mockOrganizationsUpdateCustomFields).toHaveBeenCalledWith(1, {
+          accountManager: "John Doe",
+        });
+
+        const data = JSON.parse(result.content[0].text);
+        expect(data.success).toBe(true);
       });
     });
 

--- a/src/__tests__/gateway-concurrency.test.ts
+++ b/src/__tests__/gateway-concurrency.test.ts
@@ -36,7 +36,7 @@ const { NinjaOneClientMock } = vi.hoisted(() => ({
   NinjaOneClientMock: vi.fn(),
 }));
 
-vi.mock("@wyre-technology/node-ninjaone", () => ({
+vi.mock("@wyre-ai/node-ninjaone", () => ({
   NinjaOneClient: NinjaOneClientMock,
 }));
 

--- a/src/__tests__/mcp-apps.test.ts
+++ b/src/__tests__/mcp-apps.test.ts
@@ -29,9 +29,9 @@ const { mockAlertsGet, mockAlertsReset, mockDevicesGet, mockOrgsGet } = vi.hoist
   mockOrgsGet: vi.fn(),
 }));
 
-vi.mock("@wyre-technology/node-ninjaone", async (importOriginal) => {
+vi.mock("@wyre-ai/node-ninjaone", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("@wyre-technology/node-ninjaone")>();
+    await importOriginal<typeof import("@wyre-ai/node-ninjaone")>();
   return {
     ...actual,
     NinjaOneClient: class {

--- a/src/alert-card.ts
+++ b/src/alert-card.ts
@@ -7,7 +7,7 @@
  * simply means the host renders no card while the JSON payload is unchanged.
  */
 
-import type { Alert } from "@wyre-technology/node-ninjaone";
+import type { Alert } from "@wyre-ai/node-ninjaone";
 
 export const ALERT_CARD_RESOURCE_URI = "ui://ninjaone/alert-card.html";
 

--- a/src/domains/alerts.ts
+++ b/src/domains/alerts.ts
@@ -5,7 +5,7 @@
  */
 import type { Tool } from "@modelcontextprotocol/server";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
-import type { Alert, AlertSeverity, AlertSourceType, NinjaOneClient } from "@wyre-technology/node-ninjaone";
+import type { Alert, AlertSeverity, AlertSourceType, NinjaOneClient } from "@wyre-ai/node-ninjaone";
 import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";
 import { elicitSelection } from "../utils/elicitation.js";

--- a/src/domains/devices.ts
+++ b/src/domains/devices.ts
@@ -4,7 +4,7 @@
  * Provides tools for device operations in NinjaOne.
  */
 import type { Tool } from "@modelcontextprotocol/server";
-import type { DeviceNodeClass } from "@wyre-technology/node-ninjaone";
+import type { DeviceNodeClass } from "@wyre-ai/node-ninjaone";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
 import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";
@@ -166,6 +166,36 @@ function getTools(): Tool[] {
           },
         },
         required: ["device_id"],
+      },
+    },
+    {
+      name: "ninjaone_devices_get_custom_fields",
+      description: "Get device custom fields",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          device_id: {
+            type: "number",
+          },
+        },
+        required: ["device_id"],
+      },
+    },
+    {
+      name: "ninjaone_devices_update_custom_fields",
+      description: "Update device custom fields",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          device_id: {
+            type: "number",
+          },
+          fields: {
+            type: "object",
+            description: "Custom field name/value pairs to set",
+          },
+        },
+        required: ["device_id", "fields"],
       },
     },
   ];
@@ -375,6 +405,34 @@ async function handleCall(
 
       return {
         content: [{ type: "text", text: JSON.stringify(activities, null, 2) }],
+      };
+    }
+
+    case "ninjaone_devices_get_custom_fields": {
+      const deviceId = args.device_id as number;
+      logger.info("API call: devices.getCustomFields", { deviceId });
+      const fields = await client.devices.getCustomFields(deviceId);
+      logger.debug("API response: devices.getCustomFields", { fields });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(fields, null, 2) }],
+      };
+    }
+
+    case "ninjaone_devices_update_custom_fields": {
+      const deviceId = args.device_id as number;
+      const fields = args.fields as Record<string, unknown>;
+      logger.info("API call: devices.updateCustomFields", { deviceId });
+      await client.devices.updateCustomFields(deviceId, fields);
+      logger.debug("API response: devices.updateCustomFields", { deviceId, fields });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ success: true, message: "Custom fields updated" }, null, 2),
+          },
+        ],
       };
     }
 

--- a/src/domains/organizations.ts
+++ b/src/domains/organizations.ts
@@ -99,6 +99,36 @@ function getTools(): Tool[] {
         required: ["organization_id"],
       },
     },
+    {
+      name: "ninjaone_organizations_get_custom_fields",
+      description: "Get organization custom fields",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          organization_id: {
+            type: "number",
+          },
+        },
+        required: ["organization_id"],
+      },
+    },
+    {
+      name: "ninjaone_organizations_update_custom_fields",
+      description: "Update organization custom fields",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          organization_id: {
+            type: "number",
+          },
+          fields: {
+            type: "object",
+            description: "Custom field name/value pairs to set",
+          },
+        },
+        required: ["organization_id", "fields"],
+      },
+    },
   ];
 }
 
@@ -181,6 +211,34 @@ async function handleCall(
 
       return {
         content: [{ type: "text", text: JSON.stringify(devices, null, 2) }],
+      };
+    }
+
+    case "ninjaone_organizations_get_custom_fields": {
+      const orgId = args.organization_id as number;
+      logger.info("API call: organizations.getCustomFields", { orgId });
+      const fields = await client.organizations.getCustomFields(orgId);
+      logger.debug("API response: organizations.getCustomFields", { fields });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(fields, null, 2) }],
+      };
+    }
+
+    case "ninjaone_organizations_update_custom_fields": {
+      const orgId = args.organization_id as number;
+      const fields = args.fields as Record<string, unknown>;
+      logger.info("API call: organizations.updateCustomFields", { orgId });
+      await client.organizations.updateCustomFields(orgId, fields);
+      logger.debug("API response: organizations.updateCustomFields", { orgId, fields });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ success: true, message: "Custom fields updated" }, null, 2),
+          },
+        ],
       };
     }
 

--- a/src/domains/tickets.ts
+++ b/src/domains/tickets.ts
@@ -5,7 +5,7 @@
  */
 import type { Tool } from "@modelcontextprotocol/server";
 import type { DomainHandler, CallToolResult } from "../utils/types.js";
-import type { TicketStatus, TicketPriority, TicketType } from "@wyre-technology/node-ninjaone";
+import type { TicketStatus, TicketPriority, TicketType } from "@wyre-ai/node-ninjaone";
 import { getClient } from "../utils/client.js";
 import { logger } from "../utils/logger.js";
 

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -14,7 +14,7 @@
  * silently fell through to the real SDK and made live HTTP calls). A
  * static import always resolves through the mocked binding.
  */
-import { NinjaOneClient } from "@wyre-technology/node-ninjaone";
+import { NinjaOneClient } from "@wyre-ai/node-ninjaone";
 import { AsyncLocalStorage } from "node:async_hooks";
 import {
   isValidRegion,


### PR DESCRIPTION
## Summary
- Adds `ninjaone_devices_get_custom_fields` / `ninjaone_devices_update_custom_fields` and `ninjaone_organizations_get_custom_fields` / `ninjaone_organizations_update_custom_fields` MCP tools, wrapping node-ninjaone's device custom-fields methods (already published) and its new organization custom-fields methods ([node-ninjaone#78](https://github.com/WYRE-AI/node-ninjaone/pull/78), now released as `2.1.0`).
- Requested via a community user on Discord: "There's also a request to support custom fields in the mcp."
- Also migrates the `node-ninjaone` dependency from the retired `@wyre-technology` npm scope to `@wyre-ai/node-ninjaone`. This repo's `package.json`, `.npmrc`, `Dockerfile`, and every `src/` import/test-mock were the last pieces still on the dead scope after the SDK repo itself was transferred to the `WYRE-AI` org back in `node-ninjaone` 2.0.3 — this consumer never got updated, so it's been stuck missing 2.0.2 through 2.0.4 (including a real bug fix: 400 responses were being misreported as auth failures). The organization custom-fields methods only exist under the new scope, so this migration was a hard prerequisite for the feature, not optional cleanup.
- Also corrects the git remote (`wyre-technology/ninjaone-mcp` → `WYRE-AI/ninjaone-mcp`, matching where the repo was already transferred) and fixes three leftover `@wyre-technology` mentions in README.md.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 199 passed (up from 195; +4 new tests for the custom-fields tools)
- [x] `npm run build` — clean

https://claude.ai/code/session_01AXotCDVzHE2hdJGgT1yxGY

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WYRE-AI/codesmith/ninjaone-mcp/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790695004&installation_model_id=431408&pr_number=92&repository=WYRE-AI%2Fninjaone-mcp&return_to=https%3A%2F%2Fgithub.com%2FWYRE-AI%2Fninjaone-mcp%2Fpull%2F92&signature=108fc24f8fd6cd6d8de8bedb180c544e88ce70e26578d171b3ac6bebf707a839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->